### PR TITLE
Harden release readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,14 @@
 name = "fanring"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 license = "ISC"
 description = "Bounded sharded MPSC channel built from SPSC rings"
+repository = "https://github.com/paddor/fanring.rs"
 
 [lints.rust]
 missing_debug_implementations = "deny"
+unsafe_code = "forbid"
 unsafe_op_in_unsafe_fn = "deny"
 
 [lints.rust.unexpected_cfgs]
@@ -37,6 +40,7 @@ charts = ["dep:plotters", "dep:serde", "dep:serde_json"]
 [[bench]]
 name = "comparison"
 harness = false
+test = false
 
 [[bin]]
 name = "fanring-chart"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -52,7 +52,7 @@ Ordering is FIFO per sender. Ordering across senders is intentionally relaxed.
 ## Limitations
 
 - MPSC only. No MPMC receiver set yet.
-- Max 64 senders because the ready set is a `u64`.
+- Max `fanring::MAX_SENDERS` senders because the ready set is a `u64`.
 - Dropped sender slots are not reused.
 - Capacity is per sender, so total capacity can fragment under uneven load.
 - Received slots are released back to the producer after a receive batch or when
@@ -60,7 +60,7 @@ Ordering is FIFO per sender. Ordering across senders is intentionally relaxed.
 - Global FIFO is not provided.
 - Fairness is best-effort round-robin, not strict or weighted.
 - No blocking or async API yet.
-- `fanring` itself contains no `unsafe`; it relies on `yring` for the ring
+- `fanring` itself forbids `unsafe`; it relies on `yring` for the ring
   implementation.
 
 ## Performance

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,16 +3,16 @@
 ## Checks
 
 ```sh
-cargo test
+cargo test --all-targets --features charts
 RUSTFLAGS="--cfg loom" cargo test --test loom
-cargo clippy --all-targets --features charts
+cargo clippy --all-targets --features charts -- -D warnings
 ```
 
 The test suite covers per-sender FIFO, per-sender backpressure, disconnect
 behavior, drop cleanup, sparse shard use, and the 64-bit ready mask.
 The Loom test models the ready-bit race and receiver drop handoff.
 
-`fanring` contains no direct `unsafe` code. Slot safety is delegated to
+`fanring` forbids direct `unsafe` code. Slot safety is delegated to
 `yring`, which has its own Miri/Loom coverage.
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ shared queue tail.
 ## Contract
 
 - Bounded, non-blocking MPSC.
+- `try_channel` validates configuration; `channel` panics on invalid arguments.
 - `try_send` returns immediately with `Full` instead of blocking.
 - `try_recv` returns immediately with `Empty` instead of blocking or awaiting.
 - FIFO per sender.
 - Relaxed ordering across senders.
 - Best-effort round-robin across ready senders.
-- Fixed sender limit, currently `<= 64`.
+- Fixed sender limit, currently `<= fanring::MAX_SENDERS`.
+- `try_register` reports sender-slot exhaustion vs receiver drop.
 - Capacity is per sender: `max_senders * capacity_per_sender`.
-- No `unsafe` in this crate; ring storage is delegated to `yring`.
+- `unsafe` is forbidden in this crate; ring storage is delegated to `yring`.
 
 ## Good Fit
 

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(dead_code, unused_imports))]
+
 use std::fs::{self, OpenOptions};
 use std::hint::black_box;
 use std::io::{BufWriter, Write};
@@ -43,6 +45,10 @@ struct Row {
 
 const TIME_CHECK_INTERVAL: u64 = 1024;
 
+#[cfg(test)]
+fn main() {}
+
+#[cfg(not(test))]
 fn main() {
     let duration = Duration::from_secs_f64(
         std::env::var("FANRING_BENCH_SECS")

--- a/src/bin/chart.rs
+++ b/src/bin/chart.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use plotters::prelude::*;
 use plotters::style::text_anchor::{HPos, Pos, VPos};
@@ -12,6 +14,8 @@ const GRID_COLOR: RGBColor = RGBColor(55, 65, 81);
 const AXIS_COLOR: RGBColor = RGBColor(156, 163, 175);
 const TEXT_COLOR: RGBColor = RGBColor(229, 231, 235);
 const MUTED_TEXT_COLOR: RGBColor = RGBColor(156, 163, 175);
+
+type ChartResult<T> = Result<T, ChartError>;
 
 const SERIES: &[(&str, &str, RGBColor)] = &[
     ("fanring", "fanring", RGBColor(250, 204, 21)),
@@ -43,7 +47,73 @@ struct Row {
     msgs_per_sec: f64,
 }
 
+#[derive(Debug)]
+enum ChartError {
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Json {
+        path: PathBuf,
+        line: usize,
+        source: serde_json::Error,
+    },
+    Draw(String),
+    MissingRunId,
+    NoRows {
+        path: PathBuf,
+    },
+    NoRenderableRows,
+    RunNotFound(String),
+}
+
+impl fmt::Display for ChartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(f, "{}: {source}", path.display()),
+            Self::Json { path, line, source } => {
+                write!(f, "{}:{line}: {source}", path.display())
+            }
+            Self::Draw(error) => write!(f, "draw chart: {error}"),
+            Self::MissingRunId => f.write_str("missing benchmark run id"),
+            Self::NoRows { path } => write!(f, "no benchmark rows in {}", path.display()),
+            Self::NoRenderableRows => f.write_str("no benchmark rows to render"),
+            Self::RunNotFound(run_id) => write!(f, "benchmark run id not found: {run_id}"),
+        }
+    }
+}
+
+impl Error for ChartError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Json { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+trait DrawResultExt<T> {
+    fn chart(self) -> ChartResult<T>;
+}
+
+impl<T, E> DrawResultExt<T> for Result<T, E>
+where
+    E: fmt::Debug,
+{
+    fn chart(self) -> ChartResult<T> {
+        self.map_err(|error| ChartError::Draw(format!("{error:?}")))
+    }
+}
+
 fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> ChartResult<()> {
     let input = arg_value("--input")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("target/fanring-bench/results.jsonl"));
@@ -51,44 +121,65 @@ fn main() {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("doc/charts/mpsc.svg"));
 
-    let rows = read_rows(&input);
+    let rows = read_rows(&input)?;
     if rows.is_empty() {
-        panic!("no benchmark rows in {}", input.display());
+        return Err(ChartError::NoRows { path: input });
     }
 
     let run_id = arg_value("--run")
         .or_else(|| rows.last().map(|row| row.run_id.clone()))
-        .expect("missing run id");
+        .ok_or(ChartError::MissingRunId)?;
     let rows: Vec<Row> = rows
         .into_iter()
         .filter(|row| row.run_id == run_id)
         .collect();
     if rows.is_empty() {
-        panic!("run id not found");
+        return Err(ChartError::RunNotFound(run_id));
     }
 
     if let Some(parent) = output.parent() {
-        std::fs::create_dir_all(parent).expect("create chart output dir");
+        std::fs::create_dir_all(parent).map_err(|source| ChartError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
     }
 
-    draw_chart(&rows, &output);
+    draw_chart(&rows, &output)?;
     println!("wrote {}", output.display());
+    Ok(())
 }
 
-fn read_rows(path: &PathBuf) -> Vec<Row> {
-    let file = File::open(path).expect("open benchmark JSONL");
+fn read_rows(path: &Path) -> ChartResult<Vec<Row>> {
+    let file = File::open(path).map_err(|source| ChartError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
     let mut rows = Vec::new();
-    for line in BufReader::new(file).lines() {
-        let line = line.expect("read benchmark JSONL line");
+    for (i, line) in BufReader::new(file).lines().enumerate() {
+        let line_number = i + 1;
+        let line = line.map_err(|source| ChartError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
         if line.trim().is_empty() {
             continue;
         }
-        rows.push(serde_json::from_str(&line).expect("parse benchmark JSONL row"));
+        rows.push(
+            serde_json::from_str(&line).map_err(|source| ChartError::Json {
+                path: path.to_path_buf(),
+                line: line_number,
+                source,
+            })?,
+        );
     }
-    rows
+    Ok(rows)
 }
 
-fn draw_chart(rows: &[Row], output: &PathBuf) {
+fn draw_chart(rows: &[Row], output: &Path) -> ChartResult<()> {
+    let Some(first_row) = rows.first() else {
+        return Err(ChartError::NoRenderableRows);
+    };
+
     let mut payloads: Vec<(String, usize)> = rows
         .iter()
         .map(|row| (row.payload.clone(), row.payload_bytes))
@@ -111,7 +202,7 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
     let total_h = header_h + panel_h * payloads.len() as u32 + legend_h;
 
     let root = SVGBackend::new(output, (width, total_h)).into_drawing_area();
-    root.fill(&BACKGROUND_COLOR).unwrap();
+    root.fill(&BACKGROUND_COLOR).chart()?;
 
     let title_style = ("sans-serif", 15)
         .into_font()
@@ -127,9 +218,9 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
         (width as i32 / 2, 17),
         title_style,
     ))
-    .unwrap();
+    .chart()?;
 
-    let cap = rows[0].capacity_per_sender;
+    let cap = first_row.capacity_per_sender;
     root.draw(&Text::new(
         format!(
             "X-axis: producer threads. Y-axis: million messages/sec. Higher is better. Capacity: {cap}/sender.",
@@ -137,16 +228,16 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
         (width as i32 / 2, 35),
         subtitle_style.clone(),
     ))
-    .unwrap();
+    .chart()?;
     root.draw(&Text::new(
         format!(
             "run: {}   shared-queue baselines use total capacity = producers * {cap}",
-            rows[0].run_id
+            first_row.run_id
         ),
         (width as i32 / 2, 51),
         subtitle_style,
     ))
-    .unwrap();
+    .chart()?;
 
     let (_, body) = root.split_vertically(header_h);
     let (chart_area, legend_area) = body.split_vertically(panel_h * payloads.len() as u32);
@@ -172,7 +263,7 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
                 ("sans-serif", 12).into_font().color(&TEXT_COLOR),
             )
             .build_cartesian_2d(0.0..x_max, 0.0..y_max)
-            .unwrap();
+            .chart()?;
 
         chart
             .configure_mesh()
@@ -189,9 +280,9 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
             })
             .y_label_formatter(&|y| fmt_mmsgs(*y))
             .draw()
-            .unwrap();
+            .chart()?;
 
-        draw_axis_labels(area, &producers, y_max, y_ticks);
+        draw_axis_labels(area, &producers, y_max, y_ticks)?;
 
         for (key, label, color) in SERIES {
             let by_producer: BTreeMap<usize, f64> = payload_rows
@@ -210,7 +301,7 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
 
             chart
                 .draw_series(LineSeries::new(points.clone(), color.stroke_width(3)))
-                .unwrap()
+                .chart()?
                 .label(*label)
                 .legend(|(x, y)| {
                     PathElement::new(vec![(x, y), (x + 18, y)], color.stroke_width(3))
@@ -221,11 +312,12 @@ fn draw_chart(rows: &[Row], output: &PathBuf) {
                         .into_iter()
                         .map(|point| Circle::new(point, 2, color.filled())),
                 )
-                .unwrap();
+                .chart()?;
         }
     }
 
-    draw_legend(&legend_area, rows);
+    draw_legend(&legend_area, rows)?;
+    Ok(())
 }
 
 fn draw_axis_labels(
@@ -233,7 +325,7 @@ fn draw_axis_labels(
     producers: &[usize],
     y_max: f64,
     y_ticks: usize,
-) {
+) -> ChartResult<()> {
     let tick_style = ("sans-serif", 11)
         .into_font()
         .color(&TEXT_COLOR)
@@ -266,14 +358,14 @@ fn draw_axis_labels(
             (x, plot_bottom + 17),
             tick_style.clone(),
         ))
-        .unwrap();
+        .chart()?;
     }
     area.draw(&Text::new(
         "producer threads",
         ((plot_left + plot_right) / 2, plot_bottom + 34),
         axis_style,
     ))
-    .unwrap();
+    .chart()?;
 
     for tick in 0..=y_ticks {
         let y = plot_bottom - plot_h * tick as i32 / y_ticks.max(1) as i32;
@@ -283,10 +375,11 @@ fn draw_axis_labels(
             (plot_left - 9, y),
             right_tick_style.clone(),
         ))
-        .unwrap();
+        .chart()?;
     }
     area.draw(&Text::new("M msg/s", (12, plot_top - 14), y_axis_style))
-        .unwrap();
+        .chart()?;
+    Ok(())
 }
 
 fn payload_title(rows: &[&Row]) -> String {
@@ -305,7 +398,10 @@ fn payload_title(rows: &[&Row]) -> String {
     }
 }
 
-fn draw_legend(area: &DrawingArea<SVGBackend<'_>, plotters::coord::Shift>, rows: &[Row]) {
+fn draw_legend(
+    area: &DrawingArea<SVGBackend<'_>, plotters::coord::Shift>,
+    rows: &[Row],
+) -> ChartResult<()> {
     let present: Vec<(&str, &str, RGBColor)> = SERIES
         .iter()
         .copied()
@@ -315,7 +411,7 @@ fn draw_legend(area: &DrawingArea<SVGBackend<'_>, plotters::coord::Shift>, rows:
     let label_style = ("sans-serif", 11).into_font().color(&TEXT_COLOR);
     let dim_style = ("sans-serif", 10).into_font().color(&MUTED_TEXT_COLOR);
 
-    area.draw_text("legend", &dim_style, (46, 2)).unwrap();
+    area.draw_text("legend", &dim_style, (46, 2)).chart()?;
 
     for (i, (_, label, color)) in present.iter().enumerate() {
         let col = i % 3;
@@ -326,9 +422,10 @@ fn draw_legend(area: &DrawingArea<SVGBackend<'_>, plotters::coord::Shift>, rows:
             vec![(x, y + 6), (x + 18, y + 6)],
             color.stroke_width(3),
         ))
-        .unwrap();
-        area.draw_text(label, &label_style, (x + 26, y)).unwrap();
+        .chart()?;
+        area.draw_text(label, &label_style, (x + 26, y)).chart()?;
     }
+    Ok(())
 }
 
 fn fmt_mmsgs(v: f64) -> String {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,111 @@
+use std::fmt;
+
+/// Invalid channel configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelError {
+    /// `max_senders` was zero.
+    ZeroSenders,
+    /// `max_senders` exceeded [`crate::MAX_SENDERS`].
+    TooManySenders {
+        /// Requested sender count.
+        requested: usize,
+        /// Maximum supported sender count.
+        max: usize,
+    },
+    /// `capacity_per_sender` was zero.
+    ZeroCapacity,
+    /// `capacity_per_sender` exceeded [`crate::MAX_CAPACITY_PER_SENDER`].
+    CapacityTooLarge {
+        /// Requested capacity.
+        requested: usize,
+        /// Maximum supported capacity.
+        max: usize,
+    },
+}
+
+impl fmt::Display for ChannelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::ZeroSenders => f.write_str("max_senders must be > 0"),
+            Self::TooManySenders { max, .. } => {
+                write!(f, "max_senders must be <= {max} for the ready bitmask")
+            }
+            Self::ZeroCapacity => f.write_str("capacity_per_sender must be > 0"),
+            Self::CapacityTooLarge { max, .. } => {
+                write!(f, "capacity_per_sender must be <= {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChannelError {}
+
+/// Error from [`crate::Sender::try_register`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TryRegisterError {
+    /// The receiver has been dropped.
+    Disconnected,
+    /// All sender rings are already claimed.
+    NoSenderSlot,
+}
+
+impl fmt::Display for TryRegisterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Disconnected => f.write_str("receiver has been dropped"),
+            Self::NoSenderSlot => f.write_str("all sender slots are already claimed"),
+        }
+    }
+}
+
+impl std::error::Error for TryRegisterError {}
+
+/// Error from [`crate::Sender::try_send`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendError<T> {
+    /// This sender's ring is full.
+    Full(T),
+    /// The receiver has been dropped.
+    Disconnected(T),
+}
+
+impl<T> SendError<T> {
+    /// Return the unsent value.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Full(value) | Self::Disconnected(value) => value,
+        }
+    }
+}
+
+impl<T> fmt::Display for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full(_) => f.write_str("sender ring is full"),
+            Self::Disconnected(_) => f.write_str("receiver has been dropped"),
+        }
+    }
+}
+
+impl<T: fmt::Debug> std::error::Error for SendError<T> {}
+
+/// Error from [`crate::Receiver::try_recv`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecvError {
+    /// No claimed sender ring has visible data right now.
+    Empty,
+    /// All senders are gone and all claimed rings are drained.
+    Disconnected,
+}
+
+impl fmt::Display for RecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("channel is empty"),
+            Self::Disconnected => f.write_str("all senders have been dropped"),
+        }
+    }
+}
+
+impl std::error::Error for RecvError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,26 +10,77 @@
 use std::fmt;
 
 mod compat;
+mod error;
+mod ready;
 
 use compat::{Arc, AtomicBool, AtomicU64, AtomicUsize, Mutex, Ordering};
+use ready::{ReadyMask, ReadySet, shard_bit};
 
-const MAX_SENDERS: usize = u64::BITS as usize;
+pub use error::{ChannelError, RecvError, SendError, TryRegisterError};
+
+/// Maximum number of senders supported by the ready bitmask.
+pub const MAX_SENDERS: usize = u64::BITS as usize;
+
+/// Maximum per-sender capacity accepted by [`channel`] and [`try_channel`].
+///
+/// `yring` rounds capacity up to a power of two and requires the rounded value
+/// to fit in half the cursor range.
+pub const MAX_CAPACITY_PER_SENDER: usize = 1usize << (usize::BITS - 2);
+
 const PREFETCH_LIMIT: usize = 64;
 
 /// Create a bounded sharded MPSC channel.
 ///
-/// `max_senders` includes the initial sender. It must be in `1..=64`.
-/// `capacity_per_sender` is rounded up by `yring` to the next power of two.
+/// `max_senders` includes the initial sender. It must be in
+/// `1..=`[`MAX_SENDERS`]. `capacity_per_sender` must be in
+/// `1..=`[`MAX_CAPACITY_PER_SENDER`] and is rounded up by `yring` to the next
+/// power of two.
 ///
 /// Cloning a sender is fallible: [`Sender::try_clone`] returns `None` when
 /// all sender rings are already claimed.
 pub fn channel<T>(max_senders: usize, capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
-    assert!(max_senders > 0, "max_senders must be > 0");
-    assert!(
-        max_senders <= MAX_SENDERS,
-        "max_senders must be <= 64 for the ready bitmask"
-    );
+    try_channel(max_senders, capacity_per_sender).unwrap_or_else(|error| panic!("{error}"))
+}
 
+/// Try to create a bounded sharded MPSC channel.
+///
+/// This is the fallible version of [`channel`]. It returns a [`ChannelError`]
+/// instead of panicking when the configuration is invalid.
+pub fn try_channel<T>(
+    max_senders: usize,
+    capacity_per_sender: usize,
+) -> Result<(Sender<T>, Receiver<T>), ChannelError> {
+    validate_channel_config(max_senders, capacity_per_sender)?;
+    Ok(build_channel(max_senders, capacity_per_sender))
+}
+
+fn validate_channel_config(
+    max_senders: usize,
+    capacity_per_sender: usize,
+) -> Result<(), ChannelError> {
+    if max_senders == 0 {
+        return Err(ChannelError::ZeroSenders);
+    }
+    if max_senders > MAX_SENDERS {
+        return Err(ChannelError::TooManySenders {
+            requested: max_senders,
+            max: MAX_SENDERS,
+        });
+    }
+    if capacity_per_sender == 0 {
+        return Err(ChannelError::ZeroCapacity);
+    }
+    if capacity_per_sender > MAX_CAPACITY_PER_SENDER {
+        return Err(ChannelError::CapacityTooLarge {
+            requested: capacity_per_sender,
+            max: MAX_CAPACITY_PER_SENDER,
+        });
+    }
+
+    Ok(())
+}
+
+fn build_channel<T>(max_senders: usize, capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
     let mut producers = Vec::with_capacity(max_senders);
     let mut consumers = Vec::with_capacity(max_senders);
 
@@ -44,8 +95,7 @@ pub fn channel<T>(max_senders: usize, capacity_per_sender: usize) -> (Sender<T>,
         .expect("initial producer must be present");
     let shared = Arc::new(Shared {
         unclaimed: Mutex::new(producers),
-        ready: AtomicU64::new(0),
-        shard_ready: (0..max_senders).map(|_| ReadyFlag::new(false)).collect(),
+        ready: ReadySet::new(max_senders),
         claimed: AtomicU64::new(1),
         live_senders: AtomicUsize::new(1),
         receiver_alive: AtomicBool::new(true),
@@ -57,14 +107,13 @@ pub fn channel<T>(max_senders: usize, capacity_per_sender: usize) -> (Sender<T>,
             shared: shared.clone(),
             producer,
             shard: 0,
-            bit: 1,
         },
         Receiver {
             shared,
             consumers,
             cached_available: vec![0; max_senders],
             unreleased: vec![0; max_senders],
-            ready_cache: 0,
+            ready_cache: ReadyMask::empty(),
             next_shard: 0,
         },
     )
@@ -72,8 +121,7 @@ pub fn channel<T>(max_senders: usize, capacity_per_sender: usize) -> (Sender<T>,
 
 struct Shared<T> {
     unclaimed: Mutex<Vec<Option<yring::Producer<T>>>>,
-    ready: AtomicU64,
-    shard_ready: Box<[ReadyFlag]>,
+    ready: ReadySet,
     claimed: AtomicU64,
     live_senders: AtomicUsize,
     receiver_alive: AtomicBool,
@@ -81,9 +129,12 @@ struct Shared<T> {
 }
 
 impl<T> Shared<T> {
-    fn claim_sender(&self, start_shard: usize) -> Option<(usize, yring::Producer<T>)> {
+    fn claim_sender(
+        &self,
+        start_shard: usize,
+    ) -> Result<(usize, yring::Producer<T>), TryRegisterError> {
         if !self.receiver_alive.load(Ordering::Acquire) {
-            return None;
+            return Err(TryRegisterError::Disconnected);
         }
 
         let mut unclaimed = match self.unclaimed.lock() {
@@ -96,20 +147,28 @@ impl<T> Shared<T> {
             let Some(producer) = unclaimed[shard].take() else {
                 continue;
             };
-            let bit = bit(shard);
+            if !self.receiver_alive.load(Ordering::Acquire) {
+                unclaimed[shard] = Some(producer);
+                return Err(TryRegisterError::Disconnected);
+            }
+            let bit = shard_bit(shard);
             self.claimed.fetch_or(bit, Ordering::Release);
             self.live_senders.fetch_add(1, Ordering::AcqRel);
-            return Some((shard, producer));
+            return Ok((shard, producer));
         }
 
-        None
+        if self.receiver_alive.load(Ordering::Acquire) {
+            Err(TryRegisterError::NoSenderSlot)
+        } else {
+            Err(TryRegisterError::Disconnected)
+        }
     }
 }
 
 impl<T> fmt::Debug for Shared<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Shared")
-            .field("ready", &self.ready.load(Ordering::Relaxed))
+            .field("ready", &self.ready)
             .field("claimed", &self.claimed.load(Ordering::Relaxed))
             .field("live_senders", &self.live_senders.load(Ordering::Relaxed))
             .field(
@@ -125,13 +184,13 @@ impl<T> fmt::Debug for Shared<T> {
 ///
 /// A `Sender` owns exactly one SPSC ring producer. It is `Send` when `T` is
 /// `Send`, but it is not `Sync` and cannot be cloned infallibly. Use
-/// [`try_clone`](Self::try_clone) to register another sender.
+/// [`try_clone`](Self::try_clone) or [`try_register`](Self::try_register) to
+/// register another sender.
 #[derive(Debug)]
 pub struct Sender<T> {
     shared: Arc<Shared<T>>,
     producer: yring::Producer<T>,
     shard: usize,
-    bit: u64,
 }
 
 impl<T> Sender<T> {
@@ -141,13 +200,20 @@ impl<T> Sender<T> {
     /// already claimed. Dropped sender slots are not reused in this initial
     /// design.
     pub fn try_clone(&self) -> Option<Self> {
+        self.try_register().ok()
+    }
+
+    /// Try to register another sender and report why registration failed.
+    ///
+    /// Prefer this over [`try_clone`](Self::try_clone) when the caller needs to
+    /// distinguish a closed receiver from an exhausted sender limit.
+    pub fn try_register(&self) -> Result<Self, TryRegisterError> {
         let start = self.shard.wrapping_add(1);
         let (shard, producer) = self.shared.claim_sender(start)?;
-        Some(Self {
+        Ok(Self {
             shared: self.shared.clone(),
             producer,
             shard,
-            bit: bit(shard),
         })
     }
 
@@ -193,12 +259,7 @@ impl<T> Sender<T> {
 
     #[inline]
     fn mark_ready(&self) {
-        let flag = &self.shared.shard_ready[self.shard];
-        // Publish the flush even when the shard was already ready. The
-        // receiver's matching swap synchronizes before its second prefetch.
-        if !flag.swap(true, Ordering::AcqRel) {
-            self.shared.ready.fetch_or(self.bit, Ordering::Release);
-        }
+        self.shared.ready.mark_ready(self.shard);
     }
 }
 
@@ -219,7 +280,7 @@ pub struct Receiver<T> {
     consumers: Vec<yring::Consumer<T>>,
     cached_available: Vec<usize>,
     unreleased: Vec<usize>,
-    ready_cache: u64,
+    ready_cache: ReadyMask,
     next_shard: usize,
 }
 
@@ -228,9 +289,9 @@ impl<T> Receiver<T> {
     #[inline]
     pub fn try_recv(&mut self) -> Result<T, RecvError> {
         loop {
-            if self.ready_cache == 0 {
-                self.ready_cache = self.shared.ready.swap(0, Ordering::AcqRel);
-                if self.ready_cache == 0 {
+            if self.ready_cache.is_empty() {
+                self.ready_cache = self.shared.ready.take_ready();
+                if self.ready_cache.is_empty() {
                     return if self.is_disconnected() {
                         Err(RecvError::Disconnected)
                     } else {
@@ -247,22 +308,21 @@ impl<T> Receiver<T> {
                     self.next_shard = 0;
                 }
 
-                let bit = bit(shard);
-                if self.ready_cache & bit == 0 {
+                if !self.ready_cache.contains(shard) {
                     continue;
                 }
 
-                if let Some(value) = self.try_recv_from_shard(shard, bit) {
+                if let Some(value) = self.try_recv_from_shard(shard) {
                     return Ok(value);
                 }
             }
 
-            self.ready_cache = 0;
+            self.ready_cache = ReadyMask::empty();
         }
     }
 
     #[inline]
-    fn try_recv_from_shard(&mut self, shard: usize, bit: u64) -> Option<T> {
+    fn try_recv_from_shard(&mut self, shard: usize) -> Option<T> {
         if self.cached_available[shard] > 0 {
             return Some(self.pop_cached_from_shard(shard));
         }
@@ -273,16 +333,16 @@ impl<T> Receiver<T> {
             return Some(self.pop_cached_from_shard(shard));
         }
 
-        self.shared.shard_ready[shard].swap(false, Ordering::AcqRel);
+        self.shared.ready.clear_shard(shard);
 
         let prefetched = self.consumers[shard].prefetch();
         if prefetched > 0 {
-            self.shared.shard_ready[shard].store(true, Ordering::Release);
+            self.shared.ready.restore_shard(shard);
             self.cached_available[shard] += prefetched;
             return Some(self.pop_cached_from_shard(shard));
         }
 
-        self.ready_cache &= !bit;
+        self.ready_cache.remove(shard);
         None
     }
 
@@ -309,7 +369,7 @@ impl<T> Receiver<T> {
 
         let claimed = self.shared.claimed.load(Ordering::Acquire);
         for shard in 0..self.consumers.len() {
-            if claimed & bit(shard) != 0 && !self.consumers[shard].is_disconnected() {
+            if claimed & shard_bit(shard) != 0 && !self.consumers[shard].is_disconnected() {
                 return false;
             }
         }
@@ -320,6 +380,12 @@ impl<T> Receiver<T> {
     #[inline]
     pub fn max_senders(&self) -> usize {
         self.consumers.len()
+    }
+
+    /// Return per-shard capacity after `yring` rounding.
+    #[inline]
+    pub fn capacity_per_sender(&self) -> usize {
+        self.consumers[0].capacity()
     }
 }
 
@@ -338,60 +404,8 @@ impl<T> fmt::Debug for Receiver<T> {
             .field("ready_cache", &self.ready_cache)
             .field("next_shard", &self.next_shard)
             .field("max_senders", &self.max_senders())
+            .field("capacity_per_sender", &self.capacity_per_sender())
             .finish_non_exhaustive()
-    }
-}
-
-/// Error from [`Sender::try_send`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SendError<T> {
-    /// This sender's ring is full.
-    Full(T),
-    /// The receiver has been dropped.
-    Disconnected(T),
-}
-
-impl<T> SendError<T> {
-    /// Return the unsent value.
-    #[inline]
-    pub fn into_inner(self) -> T {
-        match self {
-            Self::Full(value) | Self::Disconnected(value) => value,
-        }
-    }
-}
-
-/// Error from [`Receiver::try_recv`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RecvError {
-    /// No claimed sender ring has visible data right now.
-    Empty,
-    /// All senders are gone and all claimed rings are drained.
-    Disconnected,
-}
-
-#[inline]
-fn bit(shard: usize) -> u64 {
-    1u64 << shard
-}
-
-#[repr(align(128))]
-struct ReadyFlag(AtomicBool);
-
-impl ReadyFlag {
-    #[inline]
-    fn new(value: bool) -> Self {
-        Self(AtomicBool::new(value))
-    }
-
-    #[inline]
-    fn store(&self, value: bool, ordering: Ordering) {
-        self.0.store(value, ordering);
-    }
-
-    #[inline]
-    fn swap(&self, value: bool, ordering: Ordering) -> bool {
-        self.0.swap(value, ordering)
     }
 }
 
@@ -409,6 +423,76 @@ mod tests {
         assert_eq!(rx.try_recv(), Ok(1));
         assert_eq!(rx.try_recv(), Ok(2));
         assert_eq!(rx.try_recv(), Err(RecvError::Empty));
+    }
+
+    #[test]
+    fn try_channel_validates_config() {
+        assert_eq!(
+            try_channel::<u8>(0, 1).unwrap_err(),
+            ChannelError::ZeroSenders
+        );
+        assert_eq!(
+            try_channel::<u8>(MAX_SENDERS + 1, 1).unwrap_err(),
+            ChannelError::TooManySenders {
+                requested: MAX_SENDERS + 1,
+                max: MAX_SENDERS,
+            }
+        );
+        assert_eq!(
+            try_channel::<u8>(1, 0).unwrap_err(),
+            ChannelError::ZeroCapacity
+        );
+        assert_eq!(
+            try_channel::<u8>(1, MAX_CAPACITY_PER_SENDER + 1).unwrap_err(),
+            ChannelError::CapacityTooLarge {
+                requested: MAX_CAPACITY_PER_SENDER + 1,
+                max: MAX_CAPACITY_PER_SENDER,
+            }
+        );
+    }
+
+    #[test]
+    fn capacity_reports_yring_rounding() {
+        let (tx, rx) = try_channel::<u8>(1, 3).unwrap();
+
+        assert_eq!(tx.capacity(), 4);
+        assert_eq!(rx.capacity_per_sender(), 4);
+    }
+
+    #[test]
+    fn try_register_reports_failure_cause() {
+        let (tx, rx) = channel::<u8>(1, 1);
+        assert_eq!(
+            tx.try_register().unwrap_err(),
+            TryRegisterError::NoSenderSlot
+        );
+        drop(rx);
+        assert_eq!(
+            tx.try_register().unwrap_err(),
+            TryRegisterError::Disconnected
+        );
+        assert!(tx.try_clone().is_none());
+    }
+
+    #[test]
+    fn public_errors_implement_std_error() {
+        fn assert_error<E: std::error::Error>() {}
+
+        assert_error::<ChannelError>();
+        assert_error::<TryRegisterError>();
+        assert_error::<SendError<u8>>();
+        assert_error::<RecvError>();
+
+        assert_eq!(
+            ChannelError::ZeroSenders.to_string(),
+            "max_senders must be > 0"
+        );
+        assert_eq!(
+            TryRegisterError::NoSenderSlot.to_string(),
+            "all sender slots are already claimed"
+        );
+        assert_eq!(SendError::Full(1).to_string(), "sender ring is full");
+        assert_eq!(RecvError::Empty.to_string(), "channel is empty");
     }
 
     #[test]

--- a/src/ready.rs
+++ b/src/ready.rs
@@ -1,0 +1,114 @@
+use std::fmt;
+
+use crate::compat::{AtomicBool, AtomicU64, Ordering};
+
+/// Bitmask of shards that may have data.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReadyMask(u64);
+
+impl ReadyMask {
+    #[inline]
+    pub(crate) const fn empty() -> Self {
+        Self(0)
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    #[inline]
+    pub(crate) fn contains(self, shard: usize) -> bool {
+        self.0 & shard_bit(shard) != 0
+    }
+
+    #[inline]
+    pub(crate) fn remove(&mut self, shard: usize) {
+        self.0 &= !shard_bit(shard);
+    }
+}
+
+impl fmt::Debug for ReadyMask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ReadyMask")
+            .field(&format_args!("{:#066b}", self.0))
+            .finish()
+    }
+}
+
+/// Shared ready-state protocol.
+///
+/// Senders set a padded per-shard flag and publish the shard bit only on an
+/// empty-to-ready transition. The receiver drains the global bitmask, then uses
+/// per-shard flags to close the race with concurrent sends.
+pub(crate) struct ReadySet {
+    global: AtomicU64,
+    shards: Box<[ReadyFlag]>,
+}
+
+impl ReadySet {
+    pub(crate) fn new(max_senders: usize) -> Self {
+        Self {
+            global: AtomicU64::new(0),
+            shards: (0..max_senders).map(|_| ReadyFlag::new(false)).collect(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn mark_ready(&self, shard: usize) {
+        let flag = &self.shards[shard];
+        // Publish the flush even when the shard was already ready. The
+        // receiver's matching swap synchronizes before its second prefetch.
+        if !flag.swap(true, Ordering::AcqRel) {
+            self.global.fetch_or(shard_bit(shard), Ordering::Release);
+        }
+    }
+
+    #[inline]
+    pub(crate) fn take_ready(&self) -> ReadyMask {
+        ReadyMask(self.global.swap(0, Ordering::AcqRel))
+    }
+
+    #[inline]
+    pub(crate) fn clear_shard(&self, shard: usize) {
+        self.shards[shard].swap(false, Ordering::AcqRel);
+    }
+
+    #[inline]
+    pub(crate) fn restore_shard(&self, shard: usize) {
+        self.shards[shard].store(true, Ordering::Release);
+    }
+}
+
+impl fmt::Debug for ReadySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadySet")
+            .field("global", &ReadyMask(self.global.load(Ordering::Relaxed)))
+            .finish_non_exhaustive()
+    }
+}
+
+#[inline]
+pub(crate) fn shard_bit(shard: usize) -> u64 {
+    1u64 << shard
+}
+
+#[repr(align(128))]
+struct ReadyFlag(AtomicBool);
+
+impl ReadyFlag {
+    #[inline]
+    fn new(value: bool) -> Self {
+        Self(AtomicBool::new(value))
+    }
+
+    #[inline]
+    fn store(&self, value: bool, ordering: Ordering) {
+        self.0.store(value, ordering);
+    }
+
+    #[inline]
+    fn swap(&self, value: bool, ordering: Ordering) -> bool {
+        self.0.swap(value, ordering)
+    }
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,6 +1,6 @@
 #![cfg(all(loom, target_pointer_width = "64"))]
 
-use fanring::{RecvError, SendError, channel};
+use fanring::{RecvError, SendError, TryRegisterError, channel};
 use loom::sync::Arc;
 use loom::sync::atomic::{AtomicBool, Ordering};
 use loom::thread;
@@ -76,5 +76,80 @@ fn receiver_drop_makes_sender_disconnect() {
 
         drop(rx);
         sender.join().unwrap();
+    });
+}
+
+#[test]
+fn second_shard_ready_race_does_not_lose_message() {
+    loom::model(|| {
+        let (mut tx0, mut rx) = channel(2, 1);
+        let mut tx1 = tx0.try_clone().unwrap();
+
+        tx0.try_send(10).unwrap();
+        assert_eq!(rx.try_recv(), Ok(10));
+
+        let sender1 = thread::spawn(move || {
+            tx1.try_send(20).unwrap();
+        });
+
+        let mut received = false;
+        match rx.try_recv() {
+            Ok(20) => received = true,
+            Ok(other) => panic!("unexpected value {other}"),
+            Err(RecvError::Empty) => thread::yield_now(),
+            Err(RecvError::Disconnected) => panic!("senders still alive"),
+        }
+
+        sender1.join().unwrap();
+
+        if !received {
+            assert_eq!(rx.try_recv(), Ok(20));
+        }
+        drop(tx0);
+        assert_eq!(rx.try_recv(), Err(RecvError::Disconnected));
+    });
+}
+
+#[test]
+fn register_race_with_receiver_drop_reports_disconnected() {
+    loom::model(|| {
+        let (mut tx, rx) = channel::<u8>(2, 1);
+
+        let dropper = thread::spawn(move || {
+            thread::yield_now();
+            drop(rx);
+        });
+
+        let registered = tx.try_register();
+        dropper.join().unwrap();
+
+        match registered {
+            Ok(mut tx1) => {
+                assert_eq!(tx1.try_send(1), Err(SendError::Disconnected(1)));
+            }
+            Err(TryRegisterError::Disconnected) => {}
+            Err(TryRegisterError::NoSenderSlot) => panic!("sender slot should be available"),
+        }
+
+        assert_eq!(tx.try_send(2), Err(SendError::Disconnected(2)));
+    });
+}
+
+#[test]
+fn sender_drop_during_receiver_drain_preserves_buffered_items() {
+    loom::model(|| {
+        let (mut tx, mut rx) = channel(1, 2);
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+
+        let sender = thread::spawn(move || {
+            thread::yield_now();
+            drop(tx);
+        });
+
+        assert_eq!(rx.try_recv(), Ok(1));
+        sender.join().unwrap();
+        assert_eq!(rx.try_recv(), Ok(2));
+        assert_eq!(rx.try_recv(), Err(RecvError::Disconnected));
     });
 }


### PR DESCRIPTION
- Adds fallible channel and sender registration APIs with standard error types.
- Moves ready-bit state into a private module and forbids direct unsafe code.
- Makes chart CLI return path-aware errors instead of panicking.
- Expands Loom coverage for readiness, registration, and drain races.