### PR TITLE
Add summary performance chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.chart_hw

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -127,6 +127,25 @@ Default output: `doc/charts/mpsc.svg`.
 The chart tool selects the latest complete run, aggregates samples by median,
 and shows relative median absolute deviation below each throughput value.
 
+Generate the two-topology summary chart from the latest complete MPSC and MPMC
+runs:
+
+```sh
+cargo run --features charts --bin fanring-chart -- --summary
+```
+
+Default output: `doc/charts/summary.svg`.
+
+Chart subtitles use the ignored `.chart_hw` file in the repository root:
+
+```text
+prefix=Linux VM on a 2018 Mac Mini
+postfix=6 cores, performance governor, turbo off
+```
+
+`FANRING_HW_LABEL` overrides the complete label. `FANRING_HW_PREFIX` and
+`FANRING_HW_POSTFIX` override the corresponding file values.
+
 Custom paths:
 
 ```sh
@@ -137,4 +156,10 @@ cargo run --features charts --bin fanring-chart -- \
 cargo run --features charts --bin fanring-chart -- \
   --input target/fanring-bench/mpmc.jsonl \
   --output doc/charts/mpmc.svg
+
+cargo run --features charts --bin fanring-chart -- \
+  --summary \
+  --mpsc-input target/fanring-bench/results.jsonl \
+  --mpmc-input target/fanring-bench/mpmc.jsonl \
+  --output doc/charts/summary.svg
 ```

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Requires Rust 1.93 or newer.
 
 ## Performance
 
-Throughput across thread counts and payload sizes on the system named in each
-chart, measured with the `performance` governor and CPU turbo disabled. Cells
-show median millions of items per second; lighter cells are faster and white
-outlines mark each topology's winner.
+Median throughput on the system named in each chart, measured with the
+`performance` governor and CPU turbo disabled. Summary bars compare common
+`u64` topologies, while detailed heatmaps cover thread counts and payload sizes
+with lighter cells for higher throughput and white outlines for winners.
 
-#### MPSC
+![Common MPSC and MPMC benchmark cases](https://raw.githubusercontent.com/paddor/fanring.rs/main/doc/charts/summary.svg)
+
+#### Detailed MPSC
 
 ![MPSC benchmark chart](https://raw.githubusercontent.com/paddor/fanring.rs/main/doc/charts/mpsc.svg)
 
-#### MPMC
+#### Detailed MPMC
 
 ![MPMC benchmark chart](https://raw.githubusercontent.com/paddor/fanring.rs/main/doc/charts/mpmc.svg)
 

--- a/doc/charts/mpmc.svg
+++ b/doc/charts/mpmc.svg
@@ -4,7 +4,7 @@
 fanring MPMC comparison
 </text>
 <text x="720" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
-Intel Core i7-8700B; try operations; 5 samples; nominal capacity 8192 items
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; try operations; 5 samples; nominal capacity 8192 items
 </text>
 <text x="720" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 u64 (8 B); median M items/s (+/- MAD); color scale 0-100; white outline = winner

--- a/doc/charts/mpsc.svg
+++ b/doc/charts/mpsc.svg
@@ -4,7 +4,7 @@
 fanring MPSC comparison
 </text>
 <text x="512" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
-Intel Core i7-8700B; try operations; 5 samples; nominal capacity 8192 items
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; try operations; 5 samples; nominal capacity 8192 items
 </text>
 <text x="512" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 u64 (8 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner

--- a/doc/charts/summary.svg
+++ b/doc/charts/summary.svg
@@ -1,0 +1,69 @@
+<svg viewBox="0 0 850 430" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+<rect x="0" y="0" width="850" height="430" opacity="1" fill="#0D1117" stroke="none"/>
+<text x="425" y="22" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="12.096774193548388" opacity="1" fill="#E6EDF3" font-weight="bold">
+u64 channel throughput with capacity=8192 (higher is better)
+</text>
+<text x="425" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off
+</text>
+<text x="22" y="190" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 190)">
+million items/s
+</text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,262 830,262 "/>
+<text x="62" y="262" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+20
+</text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,205 830,205 "/>
+<text x="62" y="205" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+40
+</text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,149 830,149 "/>
+<text x="62" y="149" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+60
+</text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,92 830,92 "/>
+<text x="62" y="92" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+80
+</text>
+<polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,318 830,318 "/>
+<rect x="123" y="124" width="44" height="194" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="169" y="263" width="44" height="55" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="215" y="294" width="44" height="24" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="261" y="297" width="44" height="21" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="307" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="353" y="310" width="44" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="260" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
+MPSC: 4 producers
+</text>
+<rect x="549" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="595" y="247" width="44" height="71" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="641" y="305" width="44" height="13" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="687" y="300" width="44" height="18" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="640" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
+MPMC: 4 producers / 4 consumers
+</text>
+<rect x="65" y="364" width="12" height="12" opacity="1" fill="#F87171" stroke="none"/>
+<text x="83" y="370" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+fanring (4 x 2048-item rings)
+</text>
+<rect x="295" y="364" width="12" height="12" opacity="1" fill="#60A5FA" stroke="none"/>
+<text x="313" y="370" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+crossbeam-channel 0.5.16
+</text>
+<rect x="525" y="364" width="12" height="12" opacity="1" fill="#4ADE80" stroke="none"/>
+<text x="543" y="370" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+concurrent-queue 2.5.0
+</text>
+<rect x="65" y="384" width="12" height="12" opacity="1" fill="#A78BFA" stroke="none"/>
+<text x="83" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+thingbuf 0.1.6
+</text>
+<rect x="295" y="384" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<text x="313" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+flume 0.12.0
+</text>
+<rect x="525" y="384" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="543" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+kanal 0.1.1
+</text>
+</svg>

--- a/src/bin/chart.rs
+++ b/src/bin/chart.rs
@@ -9,13 +9,18 @@ use std::path::{Path, PathBuf};
 use plotters::prelude::*;
 use serde::Deserialize;
 
+#[path = "chart/hardware.rs"]
+mod hardware;
 #[path = "chart/render.rs"]
 mod render;
+#[path = "chart/summary.rs"]
+mod summary;
 #[path = "chart/support.rs"]
 mod support;
 
 use render::draw_chart;
-use support::{arg_value, run_is_complete};
+use summary::draw_summary_chart;
+use support::{arg_value, has_arg, run_is_complete};
 
 const BACKGROUND_COLOR: RGBColor = RGBColor(0, 0, 0);
 const GRID_COLOR: RGBColor = RGBColor(55, 65, 81);
@@ -127,6 +132,14 @@ fn main() {
 }
 
 fn run() -> ChartResult<()> {
+    if has_arg("--summary") {
+        return run_summary();
+    }
+
+    run_detail()
+}
+
+fn run_detail() -> ChartResult<()> {
     let input = arg_value("--input").map_or_else(
         || PathBuf::from("target/fanring-bench/results.jsonl"),
         PathBuf::from,
@@ -139,7 +152,44 @@ fn run() -> ChartResult<()> {
         return Err(ChartError::NoRows { path: input });
     }
 
-    let requested_run = arg_value("--run");
+    let rows = select_run(rows, arg_value("--run"))?;
+    prepare_output(&output)?;
+    draw_chart(&rows, &output)?;
+    println!("wrote {}", output.display());
+    Ok(())
+}
+
+fn run_summary() -> ChartResult<()> {
+    let mpsc_input = arg_value("--mpsc-input").map_or_else(
+        || PathBuf::from("target/fanring-bench/results.jsonl"),
+        PathBuf::from,
+    );
+    let mpmc_input = arg_value("--mpmc-input").map_or_else(
+        || PathBuf::from("target/fanring-bench/mpmc.jsonl"),
+        PathBuf::from,
+    );
+    let output = arg_value("--output")
+        .map_or_else(|| PathBuf::from("doc/charts/summary.svg"), PathBuf::from);
+
+    let mpsc_rows = read_rows_for_run(&mpsc_input, arg_value("--mpsc-run"))?;
+    let mpmc_rows = read_rows_for_run(&mpmc_input, arg_value("--mpmc-run"))?;
+    prepare_output(&output)?;
+    draw_summary_chart(&mpsc_rows, &mpmc_rows, &output)?;
+    println!("wrote {}", output.display());
+    Ok(())
+}
+
+fn read_rows_for_run(path: &Path, requested_run: Option<String>) -> ChartResult<Vec<Row>> {
+    let rows = read_rows(path)?;
+    if rows.is_empty() {
+        return Err(ChartError::NoRows {
+            path: path.to_path_buf(),
+        });
+    }
+    select_run(rows, requested_run)
+}
+
+fn select_run(rows: Vec<Row>, requested_run: Option<String>) -> ChartResult<Vec<Row>> {
     let run_id = if let Some(run_id) = requested_run {
         run_id
     } else {
@@ -157,26 +207,26 @@ fn run() -> ChartResult<()> {
             .map(str::to_owned)
             .ok_or(ChartError::NoCompleteRun)?
     };
-    let rows: Vec<Row> = rows
+    let selected: Vec<Row> = rows
         .into_iter()
         .filter(|row| row.run_id == run_id)
         .collect();
-    if rows.is_empty() {
+    if selected.is_empty() {
         return Err(ChartError::RunNotFound(run_id));
     }
-    if !run_is_complete(&rows.iter().collect::<Vec<_>>()) {
+    if !run_is_complete(&selected.iter().collect::<Vec<_>>()) {
         return Err(ChartError::RunIncomplete(run_id));
     }
+    Ok(selected)
+}
 
+fn prepare_output(output: &Path) -> ChartResult<()> {
     if let Some(parent) = output.parent() {
         std::fs::create_dir_all(parent).map_err(|source| ChartError::Io {
             path: parent.to_path_buf(),
             source,
         })?;
     }
-
-    draw_chart(&rows, &output)?;
-    println!("wrote {}", output.display());
     Ok(())
 }
 

--- a/src/bin/chart/hardware.rs
+++ b/src/bin/chart/hardware.rs
@@ -1,0 +1,86 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+pub(super) fn chart_hardware(fallback: &str) -> String {
+    configured_hardware().unwrap_or_else(|| simplify_cpu_name(fallback))
+}
+
+fn configured_hardware() -> Option<String> {
+    let config = read_chart_hardware();
+    if let Some(label) = nonempty_env("FANRING_HW_LABEL").or_else(|| {
+        config
+            .get("label")
+            .cloned()
+            .filter(|value| !value.is_empty())
+    }) {
+        return Some(label);
+    }
+
+    let prefix = nonempty_env("FANRING_HW_PREFIX").or_else(|| config.get("prefix").cloned());
+    let postfix = nonempty_env("FANRING_HW_POSTFIX").or_else(|| config.get("postfix").cloned());
+    join_hardware_parts(prefix, postfix)
+}
+
+fn read_chart_hardware() -> BTreeMap<String, String> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".chart_hw");
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return BTreeMap::new();
+    };
+
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| line.split_once('='))
+        .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+        .collect()
+}
+
+fn nonempty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn join_hardware_parts(prefix: Option<String>, postfix: Option<String>) -> Option<String> {
+    match (prefix, postfix) {
+        (Some(prefix), Some(postfix)) => Some(format!("{prefix}, {postfix}")),
+        (Some(prefix), None) => Some(prefix),
+        (None, Some(postfix)) => Some(postfix),
+        (None, None) => None,
+    }
+}
+
+fn simplify_cpu_name(cpu: &str) -> String {
+    cpu.replace("(R)", "")
+        .replace("(TM)", "")
+        .replace("CPU ", "")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{join_hardware_parts, simplify_cpu_name};
+
+    #[test]
+    fn joins_configured_hardware_parts() {
+        assert_eq!(
+            join_hardware_parts(Some("host".to_string()), Some("turbo off".to_string())),
+            Some("host, turbo off".to_string())
+        );
+        assert_eq!(
+            join_hardware_parts(Some("host".to_string()), None),
+            Some("host".to_string())
+        );
+    }
+
+    #[test]
+    fn simplifies_cpu_brand_markers() {
+        assert_eq!(
+            simplify_cpu_name("Intel(R) Core(TM) i7 CPU @ 3.20GHz"),
+            "Intel Core i7 @ 3.20GHz"
+        );
+    }
+}

--- a/src/bin/chart/render.rs
+++ b/src/bin/chart/render.rs
@@ -6,6 +6,7 @@ use plotters::element::{PathElement, Rectangle, Text};
 use plotters::prelude::{Color, IntoFont, RGBColor, SVGBackend, ShapeStyle, TextStyle};
 use plotters::style::text_anchor::{HPos, Pos, VPos};
 
+use super::hardware::chart_hardware;
 use super::{
     BACKGROUND_COLOR, ChartError, ChartResult, DrawResultExt, GRID_COLOR, MUTED_TEXT_COLOR,
     Measurement, Row, SERIES, TEXT_COLOR,
@@ -505,7 +506,7 @@ fn chart_subtitle(rows: &[Row]) -> String {
 
     format!(
         "{}; {} operations; {} samples; nominal capacity {} items",
-        simplify_cpu_name(&row.cpu),
+        chart_hardware(&row.cpu),
         row.mode,
         row.samples,
         row.nominal_capacity
@@ -526,16 +527,6 @@ fn capacity_footnote(rows: &[Row], is_mpmc: bool) -> String {
     } else {
         "Capacity: fanring uses per-ring HWM; others use one shared bound".to_string()
     }
-}
-
-fn simplify_cpu_name(cpu: &str) -> String {
-    cpu.replace("(R)", "")
-        .replace("(TM)", "")
-        .replace("CPU ", "")
-        .replace(" @ 3.20GHz", "")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
 }
 
 pub(super) fn unknown_cpu() -> String {

--- a/src/bin/chart/summary.rs
+++ b/src/bin/chart/summary.rs
@@ -1,0 +1,465 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use plotters::coord::Shift;
+use plotters::prelude::*;
+use plotters::style::text_anchor::{HPos, Pos, VPos};
+
+use super::hardware::chart_hardware;
+use super::render::measurement;
+use super::{ChartError, ChartResult, DrawResultExt, Row};
+
+const BG: RGBColor = RGBColor(0x0d, 0x11, 0x17);
+const GRID: RGBColor = RGBColor(0x21, 0x26, 0x2d);
+const AXIS: RGBColor = RGBColor(0x30, 0x36, 0x3d);
+const TEXT: RGBColor = RGBColor(0xe6, 0xed, 0xf3);
+const MUTED: RGBColor = RGBColor(0x7d, 0x85, 0x90);
+const FONT_BUMP: u32 = 1;
+
+const SERIES: &[Series] = &[
+    Series {
+        mpsc_key: "fanring",
+        mpmc_key: Some("fanring-mpmc"),
+        label: "fanring",
+        color: RGBColor(0xf8, 0x71, 0x71),
+    },
+    Series {
+        mpsc_key: "crossbeam-channel",
+        mpmc_key: Some("crossbeam-channel"),
+        label: "crossbeam-channel 0.5.16",
+        color: RGBColor(0x60, 0xa5, 0xfa),
+    },
+    Series {
+        mpsc_key: "concurrent-queue",
+        mpmc_key: None,
+        label: "concurrent-queue 2.5.0",
+        color: RGBColor(0x4a, 0xde, 0x80),
+    },
+    Series {
+        mpsc_key: "thingbuf",
+        mpmc_key: None,
+        label: "thingbuf 0.1.6",
+        color: RGBColor(0xa7, 0x8b, 0xfa),
+    },
+    Series {
+        mpsc_key: "flume",
+        mpmc_key: Some("flume"),
+        label: "flume 0.12.0",
+        color: RGBColor(0xf4, 0x72, 0xb6),
+    },
+    Series {
+        mpsc_key: "kanal",
+        mpmc_key: Some("kanal"),
+        label: "kanal 0.1.1",
+        color: RGBColor(0xf5, 0x9e, 0x0b),
+    },
+];
+
+#[derive(Clone, Copy)]
+struct Series {
+    mpsc_key: &'static str,
+    mpmc_key: Option<&'static str>,
+    label: &'static str,
+    color: RGBColor,
+}
+
+type Area<'a> = DrawingArea<SVGBackend<'a>, Shift>;
+
+pub(super) fn draw_summary_chart(
+    mpsc_rows: &[Row],
+    mpmc_rows: &[Row],
+    output: &Path,
+) -> ChartResult<()> {
+    let nominal_capacity = summary_capacity(mpsc_rows, mpmc_rows)?;
+    let groups = [
+        ("MPSC: 4 producers", summary_values(mpsc_rows, false)),
+        (
+            "MPMC: 4 producers / 4 consumers",
+            summary_values(mpmc_rows, true),
+        ),
+    ];
+    let expected_mpmc_series = SERIES
+        .iter()
+        .filter(|series| series.mpmc_key.is_some())
+        .count();
+    if groups[0].1.len() != SERIES.len() || groups[1].1.len() != expected_mpmc_series {
+        return Err(ChartError::NoRenderableRows);
+    }
+
+    let width = 850;
+    let height = 430;
+    let x_left = 70.0;
+    let x_right = 830.0;
+    let plot_width = x_right - x_left;
+    let plot_top = 62.0;
+    let plot_bottom = 318.0;
+    let max_value = groups
+        .iter()
+        .flat_map(|(_, values)| values.values().copied())
+        .fold(0.0_f64, f64::max);
+    let y_max = (max_value * 1.15).max(1.0);
+
+    let area = root(output, width, height)?;
+    let title =
+        format!("u64 channel throughput with capacity={nominal_capacity} (higher is better)");
+    chart_header(
+        &area,
+        width,
+        &title,
+        mpsc_rows
+            .first()
+            .map(|row| chart_hardware(&row.cpu))
+            .as_deref(),
+        22,
+    )?;
+    vtext(
+        &area,
+        "million items/s",
+        22,
+        px((plot_top + plot_bottom) / 2.0),
+        11,
+        TEXT,
+    )?;
+    draw_y_grid(&area, x_left, x_right, plot_top, plot_bottom, y_max)?;
+
+    let group_width = plot_width / groups.len() as f64;
+    let bar_width = 44.0;
+    let bar_gap = 2.0;
+    for (group_index, (group, values)) in groups.iter().enumerate() {
+        let active_series = SERIES
+            .iter()
+            .filter(|series| values.contains_key(series.label))
+            .collect::<Vec<_>>();
+        let cluster_width = active_series.len() as f64 * bar_width
+            + active_series.len().saturating_sub(1) as f64 * bar_gap;
+        let group_x =
+            x_left + group_index as f64 * group_width + (group_width - cluster_width) / 2.0;
+        for (series_index, series) in active_series.iter().enumerate() {
+            let Some(value) = values.get(series.label) else {
+                continue;
+            };
+            draw_bar(
+                &area,
+                group_x + series_index as f64 * (bar_width + bar_gap),
+                bar_width,
+                plot_top,
+                plot_bottom,
+                y_max,
+                *value,
+                series.color,
+            )?;
+        }
+        text(
+            &area,
+            *group,
+            px(group_x + cluster_width / 2.0),
+            px(plot_bottom + 20.0),
+            11,
+            TEXT,
+            HPos::Center,
+            true,
+        )?;
+    }
+
+    draw_legend(&area, 65.0, plot_bottom + 52.0, nominal_capacity)?;
+
+    area.present().chart()?;
+    drop(area);
+    finish_svg(output, width, height)
+}
+
+fn summary_capacity(mpsc_rows: &[Row], mpmc_rows: &[Row]) -> ChartResult<usize> {
+    let capacities = mpsc_rows
+        .iter()
+        .chain(mpmc_rows)
+        .filter(|row| row.payload == "u64" && row.producers == 4)
+        .map(|row| row.nominal_capacity)
+        .collect::<BTreeSet<_>>();
+    if capacities.len() == 1 {
+        let capacity = *capacities.first().expect("one capacity exists");
+        if capacity.is_multiple_of(4) {
+            return Ok(capacity);
+        }
+    }
+    Err(ChartError::NoRenderableRows)
+}
+
+fn summary_values(rows: &[Row], mpmc: bool) -> BTreeMap<&'static str, f64> {
+    SERIES
+        .iter()
+        .filter_map(|series| {
+            let key = if mpmc {
+                series.mpmc_key?
+            } else {
+                series.mpsc_key
+            };
+            let values = rows
+                .iter()
+                .filter(|row| {
+                    row.implementation == key
+                        && row.payload == "u64"
+                        && row.producers == 4
+                        && if mpmc {
+                            row.consumers == Some(4)
+                        } else {
+                            row.consumers.is_none()
+                        }
+                })
+                .map(|row| row.items_per_sec / 1_000_000.0)
+                .collect::<Vec<_>>();
+            (!values.is_empty()).then(|| (series.label, measurement(values).median))
+        })
+        .collect()
+}
+
+fn root(path: &Path, width: u32, height: u32) -> ChartResult<Area<'_>> {
+    let area = SVGBackend::new(path, (width, height)).into_drawing_area();
+    area.fill(&BG).chart()?;
+    Ok(area)
+}
+
+fn finish_svg(path: &Path, width: u32, height: u32) -> ChartResult<()> {
+    let mut svg = std::fs::read_to_string(path).map_err(|source| ChartError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    svg = svg.replacen(
+        &format!("<svg width=\"{width}\" height=\"{height}\" viewBox=\"0 0 {width} {height}\""),
+        &format!("<svg viewBox=\"0 0 {width} {height}\""),
+        1,
+    );
+    svg = svg.replacen(
+        "xmlns=\"http://www.w3.org/2000/svg\"",
+        "xmlns=\"http://www.w3.org/2000/svg\" font-family=\"system-ui, -apple-system, sans-serif\"",
+        1,
+    );
+    std::fs::write(path, svg).map_err(|source| ChartError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn text(
+    area: &Area<'_>,
+    value: impl Into<String>,
+    x: i32,
+    y: i32,
+    size: u32,
+    color: RGBColor,
+    horizontal: HPos,
+    bold: bool,
+) -> ChartResult<()> {
+    let mut font = ("sans-serif", size + FONT_BUMP).into_font();
+    if bold {
+        font = font.style(FontStyle::Bold);
+    }
+    let style = TextStyle::from(font)
+        .color(&color)
+        .pos(Pos::new(horizontal, VPos::Center));
+    area.draw(&Text::new(value.into(), (x, y), style)).chart()
+}
+
+fn vtext(
+    area: &Area<'_>,
+    value: &str,
+    x: i32,
+    y: i32,
+    size: u32,
+    color: RGBColor,
+) -> ChartResult<()> {
+    let font = ("sans-serif", size + FONT_BUMP)
+        .into_font()
+        .style(FontStyle::Bold)
+        .transform(FontTransform::Rotate270);
+    let style = TextStyle::from(font)
+        .color(&color)
+        .pos(Pos::new(HPos::Center, VPos::Center));
+    area.draw(&Text::new(value.to_string(), (x, y), style))
+        .chart()
+}
+
+fn rect(area: &Area<'_>, x1: f64, y1: f64, x2: f64, y2: f64, color: RGBColor) -> ChartResult<()> {
+    area.draw(&Rectangle::new(
+        [(px(x1), px(y1)), (px(x2), px(y2))],
+        ShapeStyle::from(&color).filled(),
+    ))
+    .chart()
+}
+
+fn line(
+    area: &Area<'_>,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    color: RGBColor,
+    width: u32,
+) -> ChartResult<()> {
+    area.draw(&PathElement::new(
+        vec![(px(x1), px(y1)), (px(x2), px(y2))],
+        color.stroke_width(width),
+    ))
+    .chart()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_bar(
+    area: &Area<'_>,
+    x: f64,
+    width: f64,
+    plot_top: f64,
+    plot_bottom: f64,
+    y_max: f64,
+    value: f64,
+    color: RGBColor,
+) -> ChartResult<()> {
+    let y = plot_bottom - (value / y_max) * (plot_bottom - plot_top);
+    rect(area, x, y, x + width, plot_bottom, color)
+}
+
+fn draw_y_grid(
+    area: &Area<'_>,
+    x_left: f64,
+    x_right: f64,
+    plot_top: f64,
+    plot_bottom: f64,
+    y_max: f64,
+) -> ChartResult<()> {
+    let map_y = |value: f64| plot_bottom - (value / y_max) * (plot_bottom - plot_top);
+    let step = nice_step(y_max, 5);
+    let mut value = step;
+    while value <= y_max {
+        let y = map_y(value);
+        line(area, x_left, y, x_right, y, GRID, 1)?;
+        text(
+            area,
+            format!("{value:.0}"),
+            px(x_left - 8.0),
+            px(y),
+            10,
+            MUTED,
+            HPos::Right,
+            false,
+        )?;
+        value += step;
+    }
+    line(area, x_left, plot_bottom, x_right, plot_bottom, AXIS, 2)
+}
+
+fn chart_header(
+    area: &Area<'_>,
+    width: u32,
+    title: &str,
+    hardware: Option<&str>,
+    y: i32,
+) -> ChartResult<()> {
+    let middle = i32::try_from(width / 2).expect("chart width fits i32");
+    text(area, title, middle, y, 14, TEXT, HPos::Center, true)?;
+    if let Some(hardware) = hardware {
+        text(
+            area,
+            hardware,
+            middle,
+            y + 18,
+            10,
+            MUTED,
+            HPos::Center,
+            false,
+        )?;
+    }
+    Ok(())
+}
+
+fn draw_legend(area: &Area<'_>, x: f64, y: f64, nominal_capacity: usize) -> ChartResult<()> {
+    for (index, series) in SERIES.iter().enumerate() {
+        let column = index % 3;
+        let row = index / 3;
+        let legend_x = x + column as f64 * 230.0;
+        let legend_y = y + row as f64 * 20.0;
+        rect(
+            area,
+            legend_x,
+            legend_y - 6.0,
+            legend_x + 12.0,
+            legend_y + 6.0,
+            series.color,
+        )?;
+        text(
+            area,
+            if series.mpsc_key == "fanring" {
+                format!("fanring (4 x {}-item rings)", nominal_capacity / 4)
+            } else {
+                series.label.to_string()
+            },
+            px(legend_x + 18.0),
+            px(legend_y),
+            10,
+            TEXT,
+            HPos::Left,
+            false,
+        )?;
+    }
+    Ok(())
+}
+
+fn nice_step(max_value: f64, target_lines: usize) -> f64 {
+    if max_value <= 0.0 {
+        return 1.0;
+    }
+    let raw = max_value / target_lines as f64;
+    let magnitude = 10.0_f64.powf(raw.max(1e-9).log10().floor());
+    for multiplier in [1.0, 2.0, 5.0, 10.0] {
+        let step = multiplier * magnitude;
+        if max_value / step <= target_lines as f64 + 1.0 {
+            return step;
+        }
+    }
+    magnitude * 10.0
+}
+
+fn px(value: f64) -> i32 {
+    value.round() as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SERIES, summary_values};
+    use crate::Row;
+
+    #[test]
+    fn summary_uses_same_series_for_both_groups() {
+        let mpsc = SERIES.iter().map(|series| row(series.mpsc_key, None));
+        let mpmc = SERIES
+            .iter()
+            .filter_map(|series| series.mpmc_key.map(|key| row(key, Some(4))));
+
+        let mpsc = summary_values(&mpsc.collect::<Vec<_>>(), false);
+        let mpmc = summary_values(&mpmc.collect::<Vec<_>>(), true);
+        assert_eq!(mpsc.len(), SERIES.len());
+        assert_eq!(mpmc.len(), 4);
+        for series in SERIES {
+            assert_eq!(mpsc.get(series.label), Some(&1.0));
+            assert_eq!(mpmc.get(series.label), series.mpmc_key.map(|_| &1.0));
+        }
+    }
+
+    fn row(implementation: &str, consumers: Option<usize>) -> Row {
+        Row {
+            run_id: "run".to_string(),
+            cpu: "cpu".to_string(),
+            mode: "try".to_string(),
+            implementation: implementation.to_string(),
+            payload: "u64".to_string(),
+            payload_bytes: 8,
+            producers: 4,
+            consumers,
+            nominal_capacity: 8192,
+            capacity_model: Some("per-ring-hwm".to_string()),
+            items_per_sec: 1_000_000.0,
+            sample: 0,
+            samples: 1,
+            expected_rows: 1,
+        }
+    }
+}

--- a/src/bin/chart/support.rs
+++ b/src/bin/chart/support.rs
@@ -41,6 +41,10 @@ pub(super) fn arg_value(name: &str) -> Option<String> {
     None
 }
 
+pub(super) fn has_arg(name: &str) -> bool {
+    std::env::args().skip(1).any(|arg| arg == name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::Row;


### PR DESCRIPTION
- add `--summary` chart mode for common MPSC and MPMC topologies
- preserve implementation colors and display benchmarked dependency versions
- read ignored `.chart_hw` metadata into every chart subtitle
- show the summary chart before detailed README heatmaps