### PR TITLE
Replace crossbeam deque with internal work queues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,25 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,7 +86,6 @@ dependencies = [
  "arc-swap",
  "concurrent-queue",
  "crossbeam-channel",
- "crossbeam-deque",
  "flume",
  "kanal",
  "loom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ check-cfg = ["cfg(loom)"]
 [dependencies]
 arc-swap = "1.7"
 concurrent-queue = { version = "2.5", features = ["loom"] }
-crossbeam-deque = "0.8.7"
 plotters = { version = "0.3", optional = true, default-features = false, features = ["svg_backend"] }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,11 +26,11 @@ tokens. The immutable page/group topology is published with `ArcSwap` only
 when registration crosses a 64-lane boundary; each receiver caches it until a
 generation change.
 
-The registry also tracks one work stealer per live receiver. Receiver creation
-and drop rebuild a single immutable stealer snapshot under the registry mutex
+The registry also tracks one bounded work queue per live receiver. Receiver
+creation and drop rebuild an immutable queue snapshot under the registry mutex
 and publish it with `ArcSwap`. Receivers load that snapshot without locking
-only after their local deque and the shared injector miss. Persistent stealer
-storage is linear in the number of receivers.
+only after their own queue, the shared orphan queue, and visible sender lanes
+miss. Persistent work-queue storage is linear in the number of receivers.
 
 ## Send Path
 
@@ -80,18 +80,17 @@ parking while partial credits remain unpublished.
 
 ## MPMC Receive Path
 
-Each receiver owns a FIFO work deque. A receive operation checks its local
-deque, the shared injector, and other receivers' stealers before claiming a
-ready sender lane. Each shared source gets one steal attempt per sweep. A
-contended sweep advances the victim cursor, checks ready sender lanes, and then
-retries before parking. One busy deque cannot hide later victims or ready
-lanes.
+Each receiver owns a bounded lock-free work queue. A receive first checks its
+local queue and the shared orphan queue. If a sender lane is visibly ready, it
+claims that lane before stealing so multiple producers naturally spread across
+receivers. Otherwise it rotates through the other receiver queues and steals a
+batch.
 
-After claiming a lane, it prefetches and removes at most 64 values. The first
-value satisfies the current receive. Remaining values move to the receiver's
-local deque and are immediately stealable in batches. The lane token is then
-requeued or returned to the registry; no receiver retains a sender lane between
-API calls.
+After claiming a lane, a receiver prefetches and removes at most 64 values. The
+first value satisfies the current receive. Remaining values move to the local
+work queue and become immediately stealable. A steal returns one value and
+moves at most seven more into the thief's local queue, bounding transfer work
+while amortizing victim discovery.
 
 Receivers normally pop directly from a remembered page queue, allowing
 multiple receivers to claim different lanes concurrently. Bitmap summaries
@@ -102,26 +101,22 @@ remain inside the publication tracker. Page queues are bounded by the 64 lane
 tokens that can belong to them, so steady requeue traffic performs no heap
 allocation.
 
-Draining a receiver's local work before claiming another lane preserves
-batching. Requeuing every sender lane after at most 64 values bounds domination
-by an always-busy lane. Receiver drop moves its remaining local values to the
-shared injector and wakes competitors. This is one topology for all receiver
-counts; there is no single-consumer specialization.
+Local queues are bounded by the largest 64-value prefetch batch and allocate
+once when a receiver is created. Receiver drop moves any remaining local values
+to the shared unbounded orphan queue and wakes competitors. This is one
+topology for all receiver counts; there is no single-consumer specialization.
 
 A publication tracker protects transfers that can make work temporarily
-invisible: lane acquisition and drain, publication into a local FIFO, lane
-requeue or retirement, and receiver handoff or removal. Publishers increment a
-generation before decrementing the in-flight count. An empty receiver scan can
-return `Disconnected` only when its generation is unchanged, no publication is
-in flight, all senders are gone, and all sender lanes are retired. Contention or
-a changed generation produces a bounded retry; exhaustion reports transient
-`Empty`, never premature `Disconnected`.
+invisible: lane acquisition and drain, work-queue stealing, lane requeue or
+retirement, and receiver handoff or removal. Publishers increment a generation
+before decrementing the in-flight count. An empty receiver scan can return
+`Disconnected` only when its generation is unchanged, no publication is in
+flight, all senders are gone, and all sender lanes are retired. A changed
+generation produces a bounded retry; exhaustion reports transient `Empty`,
+never premature `Disconnected`.
 
-MPMC ordering is relaxed. This permits batches from one sender lane to execute
-concurrently and permits later sender batches to overtake earlier local work.
-Local and injector work is checked before sender lanes. This may delay a ready
-lane behind a finite staged backlog, but staged work is drained or stolen and
-sender batches remain bounded at 64 values.
+MPMC ordering is relaxed. Batches from one sender can execute concurrently, and
+values from different sender rings may overtake each other.
 
 ## Blocking Waits
 
@@ -161,6 +156,6 @@ sends return `Disconnected`.
 MPSC ordering is FIFO within one sender lane and relaxed across lanes. MPMC
 ordering is fully relaxed. Capacity is per sender, like a per-pipe ZMQ HWM.
 Adding a sender adds another ring and another capacity allocation. No shared
-global credit counter appears on the send path. MPMC receiver deques and the
-injector hold prefetched values outside those ring HWMs, so the sum of ring
+global credit counter appears on the send path. MPMC receiver queues and the
+orphan queue hold prefetched values outside those ring HWMs, so the sum of ring
 capacities is a nominal bound rather than an exact total resident-item bound.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,11 +26,12 @@ tokens. The immutable page/group topology is published with `ArcSwap` only
 when registration crosses a 64-lane boundary; each receiver caches it until a
 generation change.
 
-The registry also tracks one bounded work queue per live receiver. Receiver
-creation and drop rebuild an immutable queue snapshot under the registry mutex
-and publish it with `ArcSwap`. Receivers load that snapshot without locking
-only after their own queue, the shared orphan queue, and visible sender lanes
-miss. Persistent work-queue storage is linear in the number of receivers.
+The registry also tracks one bounded synchronized work queue per live receiver.
+Receiver creation and drop rebuild an immutable queue snapshot under the
+registry mutex and publish it with `ArcSwap`. Receivers load the snapshot itself
+without locking only after their own queue, the shared orphan queue, and visible
+sender lanes miss. Persistent work-queue storage is linear in the number of
+receivers.
 
 ## Send Path
 
@@ -80,17 +81,20 @@ parking while partial credits remain unpublished.
 
 ## MPMC Receive Path
 
-Each receiver owns a bounded lock-free work queue. A receive first checks its
-local queue and the shared orphan queue. If a sender lane is visibly ready, it
-claims that lane before stealing so multiple producers naturally spread across
-receivers. Otherwise it rotates through the other receiver queues and steals a
-batch.
+Each receiver owns a private deque and a bounded synchronized work queue. A
+receive first checks the private deque, its shared queue, and the shared orphan
+queue. If a sender lane is visibly ready, it claims that lane before stealing
+so multiple producers naturally spread across receivers. Otherwise it rotates
+through the other receiver queues and steals a batch.
 
 After claiming a lane, a receiver prefetches and removes at most 64 values. The
-first value satisfies the current receive. Remaining values move to the local
-work queue and become immediately stealable. A steal returns one value and
-moves at most seven more into the thief's local queue, bounding transfer work
-while amortizing victim discovery.
+first value satisfies the current receive. With one live receiver, remaining
+values move to its private deque. Cloning publishes that private work before
+registering the new receiver. With multiple receivers, remaining values move to
+the synchronized queue under one bounded critical section and become
+immediately stealable. A steal returns one value and moves at most seven more
+into the thief's queue, bounding transfer work while amortizing victim
+discovery.
 
 Receivers normally pop directly from a remembered page queue, allowing
 multiple receivers to claim different lanes concurrently. Bitmap summaries
@@ -102,9 +106,10 @@ tokens that can belong to them, so steady requeue traffic performs no heap
 allocation.
 
 Local queues are bounded by the largest 64-value prefetch batch and allocate
-once when a receiver is created. Receiver drop moves any remaining local values
-to the shared unbounded orphan queue and wakes competitors. This is one
-topology for all receiver counts; there is no single-consumer specialization.
+once when a receiver is created. Receiver drop moves private and shared local
+values to the synchronized unbounded orphan queue and wakes competitors. The
+single-receiver private deque removes synchronization from the uncontended
+receive path without changing clone or drop reachability.
 
 A publication tracker protects transfers that can make work temporarily
 invisible: lane acquisition and drain, work-queue stealing, lane requeue or

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,8 +126,8 @@ Default output: `doc/charts/mpsc.svg`.
 The chart tool selects the latest complete run, aggregates samples by median,
 and shows relative median absolute deviation below each throughput value.
 
-Generate the two-topology summary chart from the latest complete MPSC and MPMC
-runs:
+Generate the two-topology summary chart from the latest complete nonblocking
+MPSC and MPMC runs:
 
 ```sh
 cargo run --features charts --bin fanring-chart -- --summary

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,9 +27,10 @@ boundaries. `LOOM_MAX_BRANCHES`,
 defaults for deeper local runs.
 
 `fanring` forbids direct `unsafe` code. Slot safety is delegated to
-`yring`, which has its own Miri/Loom coverage. MPMC lane queues use
-`concurrent-queue`'s Loom backend. `ArcSwap` topology publication is covered by
-normal stress tests and sanitizer runs.
+`yring`, which has its own Miri/Loom coverage. MPMC lane-token queues use
+`concurrent-queue`'s Loom backend, while receiver work queues use the
+compatibility mutex and are directly modeled. `ArcSwap` topology publication
+is covered by normal stress tests and sanitizer runs.
 
 ## Release
 
@@ -123,8 +124,9 @@ cargo run --features charts --bin fanring-chart
 
 Default output: `doc/charts/mpsc.svg`.
 
-The chart tool selects the latest complete run, aggregates samples by median,
-and shows relative median absolute deviation below each throughput value.
+The chart tool selects the latest complete nonblocking run, aggregates samples
+by median, and shows relative median absolute deviation below each throughput
+value. An explicit run ID may select a blocking run.
 
 Generate the two-topology summary chart from the latest complete nonblocking
 MPSC and MPMC runs:
@@ -139,7 +141,7 @@ Chart subtitles use the ignored `.chart_hw` file in the repository root:
 
 ```text
 prefix=Linux VM on a 2018 Mac Mini
-postfix=6 cores, performance governor, turbo off
+postfix=6 physical cores / 12 threads, performance governor, turbo off
 ```
 
 `FANRING_HW_LABEL` overrides the complete label. `FANRING_HW_PREFIX` and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,30 +7,29 @@ cargo test --all-features
 cargo clippy --all-targets --all-features -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
 RUSTFLAGS="--cfg loom" cargo test --lib --test loom -- --test-threads=1
-cargo +nightly miri test --test mpsc --test stress -- --test-threads=1
-MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-permissive-provenance -Zmiri-ignore-leaks" \
+cargo +nightly miri test --all-features -- --test-threads=1
+MIRIFLAGS="-Zmiri-tree-borrows" \
   cargo +nightly miri test --all-features -- --test-threads=1
 ```
 
 The test suite covers per-sender FIFO, per-sender backpressure, disconnect and
 timeout races, drop cleanup, dynamic lane registration and reuse, ready
-page/group boundaries, starvation bounds, MPMC batch publication and receiver
+page/group boundaries, starvation bounds, MPMC batch stealing and receiver
 churn, randomized endpoint state machines, unusual value layouts, and the
 64-bit ready mask. Small private wait-cell, readiness, and publication-tracker
 Loom models are exhaustive. End-to-end channel models use a preemption bound
 of two and at most 10,000 permutations.
 
-Loom reduces pages and groups to two entries and the MPMC batch limit to two,
-so small models cross topology and requeue boundaries. `LOOM_MAX_BRANCHES`,
+Loom reduces pages and groups to two entries and the MPMC work-queue capacity
+and release batch to two, so small models cross topology and requeue
+boundaries. `LOOM_MAX_BRANCHES`,
 `LOOM_MAX_PERMUTATIONS`, and `LOOM_MAX_PREEMPTIONS` override the end-to-end
 defaults for deeper local runs.
 
 `fanring` forbids direct `unsafe` code. Slot safety is delegated to
-`yring`, which has its own Miri/Loom coverage. Crossbeam deque and `ArcSwap`
-internals are not Loom-instrumented here; normal stress tests cover their
-integration with fanring. The full Miri run uses Tree Borrows and ignores
-process-global leaks because `crossbeam-epoch` does not pass Miri's default
-Stacked Borrows and leak checks. The MPSC-only run keeps those checks enabled.
+`yring`, which has its own Miri/Loom coverage. MPMC lane queues use
+`concurrent-queue`'s Loom backend. `ArcSwap` topology publication is covered by
+normal stress tests and sanitizer runs.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Fast typed MPSC and MPMC channels built from one SPSC `yring` per producer.
 
 Sender registration is dynamic. Each sender writes to its own ring, so
 producers do not contend on a shared queue tail. MPSC drains those rings
-directly; MPMC distributes internally batched work through stealable
-receiver-local FIFOs.
+directly; MPMC stages prefetched batches in stealable receiver-local queues.
 
 Requires Rust 1.93 or newer.
 
@@ -65,15 +64,15 @@ let b = rx1.recv().unwrap();
 assert_ne!(a, b);
 ```
 
-`mpmc` drains ready sender rings in batches of at most 64. One item is returned
-and the rest enter the receiver's local FIFO, where other receivers can steal
-them in batches. Receiver drop republishes its buffered work. Ordering is
-relaxed. Moving values into that second-stage queue costs more for large inline
-types; box large payloads when move bandwidth dominates.
+`mpmc` drains up to 64 values from a ready sender ring into a bounded local work
+queue. Competing receivers steal up to eight values at a time. Receiver drop
+republishes its buffered work. Ordering is relaxed. Moving values into that
+second-stage queue costs more for large inline types; box large payloads when
+move bandwidth dominates.
 
 `mpmc::try_recv` may return a transient `Empty` while bounded lane maintenance
 or another receiver moves work. `Disconnected` is final: all senders are gone,
-sender rings are drained, no staged work remains, and no work publication is in
+sender rings and staged queues are drained, and no work publication is in
 flight.
 
 ## Contract

--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ let b = rx1.recv().unwrap();
 assert_ne!(a, b);
 ```
 
-`mpmc` drains up to 64 values from a ready sender ring into a bounded local work
-queue. Competing receivers steal up to eight values at a time. Receiver drop
-republishes its buffered work. Ordering is relaxed. Moving values into that
-second-stage queue costs more for large inline types; box large payloads when
-move bandwidth dominates.
+`mpmc` drains up to 64 values from a ready sender ring. With one receiver, the
+remaining values stay in a private deque. Cloning publishes that deque before
+the new receiver becomes visible. With multiple receivers, remaining values
+enter bounded synchronized work queues, and competitors steal up to eight at a
+time. Receiver drop republishes its buffered work. Ordering is relaxed. Moving
+values into that second-stage queue costs more for large inline types; box large
+payloads when move bandwidth dominates.
 
 `mpmc::try_recv` may return a transient `Empty` while bounded lane maintenance
 or another receiver moves work. `Disconnected` is final: all senders are gone,
@@ -85,8 +87,9 @@ flight.
   Blocking operations spin briefly before parking.
 - Disconnection never discards buffered values. MPMC `Empty` may be transient
   while receivers move internal work; `Disconnected` is final.
-- Common try paths are lock-free, not wait-free. Topology changes, maintenance,
-  and parking may lock or allocate.
+- Sender hot paths and MPSC batching avoid a shared queue lock. MPMC work
+  distribution and topology maintenance use mutexes; blocking operations may
+  park.
 
 ## Good Fit
 

--- a/doc/charts/mpmc.svg
+++ b/doc/charts/mpmc.svg
@@ -4,7 +4,7 @@
 fanring MPMC comparison
 </text>
 <text x="720" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; try operations; 5 samples; nominal capacity 8192 items
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; blocking operations; 5 samples; nominal capacity 8192 items
 </text>
 <text x="720" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 u64 (8 B); median M items/s (+/- MAD); color scale 0-100; white outline = winner
@@ -81,482 +81,482 @@ implementation
 <text x="28" y="161" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="149" width="71" height="25" opacity="1" fill="#365784" stroke="none"/>
+<rect x="186" y="149" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
 <rect x="186" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-41.4
+21.3
 </text>
 <text x="221" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-5.8%
 </text>
-<rect x="261" y="149" width="71" height="25" opacity="1" fill="#416DA4" stroke="none"/>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="#304C72" stroke="none"/>
 <rect x="261" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-57.5
+32.8
 </text>
 <text x="296" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.5%
++/-9.6%
 </text>
-<rect x="336" y="149" width="71" height="25" opacity="1" fill="#2D466A" stroke="none"/>
+<rect x="336" y="149" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
 <rect x="336" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-28.5
+30.1
 </text>
 <text x="371" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
++/-1.0%
 </text>
-<rect x="411" y="149" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="#2A4264" stroke="none"/>
 <rect x="411" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.0
+25.7
 </text>
 <text x="446" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.7%
++/-2.8%
 </text>
-<rect x="494" y="149" width="71" height="25" opacity="1" fill="#365783" stroke="none"/>
-<rect x="494" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="494" y="149" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
 <text x="529" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-41.2
+18.2
 </text>
 <text x="529" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-2.0%
 </text>
-<rect x="569" y="149" width="71" height="25" opacity="1" fill="#4472AC" stroke="none"/>
+<rect x="569" y="149" width="71" height="25" opacity="1" fill="#345480" stroke="none"/>
 <rect x="569" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-61.6
+39.5
 </text>
 <text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-1.0%
 </text>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="#497BBA" stroke="none"/>
 <rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-83.7
+68.5
 </text>
 <text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.7%
 </text>
-<rect x="719" y="149" width="71" height="25" opacity="1" fill="#416CA4" stroke="none"/>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="#426DA5" stroke="none"/>
 <rect x="719" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-57.4
+57.9
 </text>
 <text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-12.1%
++/-1.1%
 </text>
-<rect x="802" y="149" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
-<rect x="802" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="802" y="149" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
 <text x="837" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-40.8
+13.7
 </text>
 <text x="837" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.8%
 </text>
-<rect x="877" y="149" width="71" height="25" opacity="1" fill="#4471AB" stroke="none"/>
+<rect x="877" y="149" width="71" height="25" opacity="1" fill="#2F4B72" stroke="none"/>
 <rect x="877" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-60.7
+32.6
 </text>
 <text x="912" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-0.8%
 </text>
-<rect x="952" y="149" width="71" height="25" opacity="1" fill="#5189CF" stroke="none"/>
+<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4471AA" stroke="none"/>
 <rect x="952" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-78.9
+<text x="987" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+60.6
 </text>
-<text x="987" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-4.7%
+<text x="987" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
 </text>
-<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5C9EEF" stroke="none"/>
+<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5DA0F2" stroke="none"/>
 <rect x="1027" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-94.5
+96.1
 </text>
 <text x="1062" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.0%
++/-3.3%
 </text>
-<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#345480" stroke="none"/>
-<rect x="1110" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="1145" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-39.4
+9.6
 </text>
 <text x="1145" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.2%
++/-4.0%
 </text>
-<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#3B6193" stroke="none"/>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#243752" stroke="none"/>
 <rect x="1185" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-48.9
+16.9
 </text>
 <text x="1220" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
++/-0.2%
 </text>
-<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#416CA3" stroke="none"/>
+<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#355580" stroke="none"/>
 <rect x="1260" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-57.0
+39.8
 </text>
 <text x="1295" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
++/-2.5%
 </text>
-<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#538DD6" stroke="none"/>
+<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#4E83C7" stroke="none"/>
 <rect x="1335" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-82.0
+74.5
 </text>
 <text x="1370" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-2.6%
++/-0.9%
 </text>
 <text x="28" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="178" width="71" height="25" opacity="1" fill="#243550" stroke="none"/>
+<rect x="186" y="178" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
 <text x="221" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.0
+13.8
 </text>
 <text x="221" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.8%
++/-1.6%
 </text>
-<rect x="261" y="178" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="261" y="178" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
 <text x="296" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.9
+12.5
 </text>
 <text x="296" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.9%
++/-5.0%
 </text>
-<rect x="336" y="178" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<rect x="336" y="178" width="71" height="25" opacity="1" fill="#1F2E45" stroke="none"/>
 <text x="371" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.1
+10.4
 </text>
 <text x="371" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-1.5%
 </text>
-<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1F2C42" stroke="none"/>
 <text x="446" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.8
+9.1
 </text>
 <text x="446" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.2%
++/-5.8%
 </text>
-<rect x="494" y="178" width="71" height="25" opacity="1" fill="#2F4B72" stroke="none"/>
+<rect x="494" y="178" width="71" height="25" opacity="1" fill="#314E75" stroke="none"/>
+<rect x="494" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-32.4
+34.3
 </text>
 <text x="529" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.7%
++/-23.1%
 </text>
-<rect x="569" y="178" width="71" height="25" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="569" y="178" width="71" height="25" opacity="1" fill="#243752" stroke="none"/>
 <text x="604" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-26.3
+17.1
 </text>
 <text x="604" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-32.3%
++/-15.5%
 </text>
-<rect x="644" y="178" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="644" y="178" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
 <text x="679" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.4
-</text>
-<text x="679" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.5%
-</text>
-<rect x="719" y="178" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
-<text x="754" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10.7
 </text>
-<text x="754" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.4%
+<text x="679" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.7%
 </text>
-<rect x="802" y="178" width="71" height="25" opacity="1" fill="#253854" stroke="none"/>
+<rect x="719" y="178" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="754" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.0
+</text>
+<text x="754" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.4%
+</text>
+<rect x="802" y="178" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<rect x="802" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="837" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.9
+18.1
 </text>
 <text x="837" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-6.6%
 </text>
 <rect x="877" y="178" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
 <text x="912" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 19.0
 </text>
 <text x="912" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
++/-4.0%
 </text>
-<rect x="952" y="178" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="952" y="178" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
 <text x="987" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.0
+19.0
 </text>
 <text x="987" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.7%
++/-17.6%
 </text>
-<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
 <text x="1062" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.6
+10.9
 </text>
 <text x="1062" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-6.8%
 </text>
 <rect x="1110" y="178" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<rect x="1110" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1145" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.8
-</text>
-<text x="1145" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.9%
-</text>
-<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
-<text x="1220" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.0
-</text>
-<text x="1220" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.9%
-</text>
-<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
-<text x="1295" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.8
-</text>
-<text x="1295" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-12.9%
-</text>
-<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
-<text x="1370" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 12.7
 </text>
+<text x="1145" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.5%
+</text>
+<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<text x="1220" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.6
+</text>
+<text x="1220" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.0%
+</text>
+<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="1295" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.7
+</text>
+<text x="1295" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.2%
+</text>
+<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<text x="1370" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.1
+</text>
 <text x="1370" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.6%
++/-8.7%
 </text>
 <text x="28" y="219" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="207" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="186" y="207" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
 <text x="221" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
+7.9
 </text>
 <text x="221" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
++/-7.1%
 </text>
-<rect x="261" y="207" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
+<rect x="261" y="207" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="296" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.3
+7.4
 </text>
 <text x="296" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.0%
++/-0.8%
 </text>
-<rect x="336" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="336" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="371" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.4
+3.1
 </text>
 <text x="371" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.6%
++/-14.7%
 </text>
-<rect x="411" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<rect x="411" y="207" width="71" height="25" opacity="1" fill="#182031" stroke="none"/>
 <text x="446" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
+0.3
 </text>
 <text x="446" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-1.2%
 </text>
-<rect x="494" y="207" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="494" y="207" width="71" height="25" opacity="1" fill="#1E2A3F" stroke="none"/>
 <text x="529" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.4
+7.7
 </text>
 <text x="529" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
++/-1.4%
 </text>
-<rect x="569" y="207" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="569" y="207" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="604" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
+6.8
 </text>
 <text x="604" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-4.7%
 </text>
 <rect x="644" y="207" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="679" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.3
+5.4
 </text>
 <text x="679" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-3.4%
 </text>
-<rect x="719" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="719" y="207" width="71" height="25" opacity="1" fill="#192234" stroke="none"/>
 <text x="754" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.0
+1.8
 </text>
 <text x="754" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-17.4%
++/-12.9%
 </text>
-<rect x="802" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="802" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="837" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
+3.9
 </text>
 <text x="837" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-3.9%
 </text>
-<rect x="877" y="207" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="877" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="912" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.2
+3.9
 </text>
 <text x="912" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-4.0%
 </text>
-<rect x="952" y="207" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<rect x="952" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="987" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.8
+4.6
 </text>
 <text x="987" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-6.9%
 </text>
-<rect x="1027" y="207" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<rect x="1027" y="207" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
 <text x="1062" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
+3.4
 </text>
 <text x="1062" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.7%
++/-0.2%
 </text>
-<rect x="1110" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<rect x="1110" y="207" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
 <text x="1145" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
+1.0
 </text>
 <text x="1145" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.2%
++/-4.9%
 </text>
-<rect x="1185" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="1185" y="207" width="71" height="25" opacity="1" fill="#192131" stroke="none"/>
 <text x="1220" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.0
+0.7
 </text>
 <text x="1220" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.5%
++/-18.1%
 </text>
-<rect x="1260" y="207" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<rect x="1260" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1295" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
+1.6
 </text>
 <text x="1295" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-6.8%
 </text>
-<rect x="1335" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="1335" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="1370" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
+4.1
 </text>
 <text x="1370" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
++/-2.4%
 </text>
 <text x="28" y="248" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="236" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
+<rect x="186" y="236" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="221" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.9
+6.9
 </text>
 <text x="221" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-22.3%
++/-15.1%
 </text>
-<rect x="261" y="236" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<rect x="261" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="296" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
+3.8
 </text>
 <text x="296" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-49.0%
++/-24.2%
 </text>
 <rect x="336" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="371" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.3
 </text>
 <text x="371" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-30.4%
++/-29.0%
 </text>
-<rect x="411" y="236" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="411" y="236" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="446" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.6
+2.4
 </text>
 <text x="446" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-26.0%
++/-15.9%
 </text>
-<rect x="494" y="236" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
+<rect x="494" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="529" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.1
+3.8
 </text>
 <text x="529" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-50.8%
++/-7.2%
 </text>
 <rect x="569" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="604" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+4.3
 </text>
 <text x="604" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-39.3%
++/-19.4%
 </text>
-<rect x="644" y="236" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="644" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="679" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.6
+5.2
 </text>
 <text x="679" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-5.7%
 </text>
-<rect x="719" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="719" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="754" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.4
+3.0
 </text>
 <text x="754" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-16.6%
++/-8.1%
 </text>
-<rect x="802" y="236" width="71" height="25" opacity="1" fill="#192234" stroke="none"/>
+<rect x="802" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="837" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
+3.2
 </text>
 <text x="837" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-30.3%
++/-15.6%
 </text>
-<rect x="877" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<rect x="877" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="912" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.0
+4.3
 </text>
 <text x="912" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-20.5%
++/-13.2%
 </text>
-<rect x="952" y="236" width="71" height="25" opacity="1" fill="#1C283D" stroke="none"/>
+<rect x="952" y="236" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="987" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.2
+5.5
 </text>
 <text x="987" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.3%
++/-12.1%
 </text>
-<rect x="1027" y="236" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<rect x="1027" y="236" width="71" height="25" opacity="1" fill="#1C283B" stroke="none"/>
 <text x="1062" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.1
+5.7
 </text>
 <text x="1062" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.8%
++/-9.0%
 </text>
-<rect x="1110" y="236" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<rect x="1110" y="236" width="71" height="25" opacity="1" fill="#192234" stroke="none"/>
 <text x="1145" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
+1.7
 </text>
 <text x="1145" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-30.3%
++/-9.1%
 </text>
 <rect x="1185" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="1220" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.1
+4.0
 </text>
 <text x="1220" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-21.9%
++/-8.6%
 </text>
-<rect x="1260" y="236" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
+<rect x="1260" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="1295" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.4
+4.9
 </text>
 <text x="1295" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-25.8%
++/-1.5%
 </text>
-<rect x="1335" y="236" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="1335" y="236" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
 <text x="1370" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.1
+5.9
 </text>
 <text x="1370" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-17.9%
++/-6.9%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,293 1416,293 "/>
 <text x="720" y="309" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes64 (64 B); median M items/s (+/- MAD); color scale 0-60; white outline = winner
+bytes64 (64 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner
 </text>
 <text x="172" y="333" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 producer threads
@@ -630,482 +630,482 @@ implementation
 <text x="28" y="397" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="385" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="186" y="385" width="71" height="25" opacity="1" fill="#23354F" stroke="none"/>
 <text x="221" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.2
+12.4
 </text>
 <text x="221" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-0.3%
 </text>
-<rect x="261" y="385" width="71" height="25" opacity="1" fill="#3B6193" stroke="none"/>
+<rect x="261" y="385" width="71" height="25" opacity="1" fill="#314E76" stroke="none"/>
 <rect x="261" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.5
+27.6
 </text>
 <text x="296" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
++/-0.4%
 </text>
-<rect x="336" y="385" width="71" height="25" opacity="1" fill="#34537E" stroke="none"/>
+<rect x="336" y="385" width="71" height="25" opacity="1" fill="#33537D" stroke="none"/>
 <rect x="336" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-23.1
+30.5
 </text>
 <text x="371" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-17.4%
++/-1.5%
 </text>
-<rect x="411" y="385" width="71" height="25" opacity="1" fill="#2D476B" stroke="none"/>
+<rect x="411" y="385" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
 <rect x="411" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.6
+24.2
 </text>
 <text x="446" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-2.3%
 </text>
-<rect x="494" y="385" width="71" height="25" opacity="1" fill="#2D486C" stroke="none"/>
+<rect x="494" y="385" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
 <text x="529" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.9
+11.0
 </text>
 <text x="529" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.3%
 </text>
-<rect x="569" y="385" width="71" height="25" opacity="1" fill="#3C6294" stroke="none"/>
+<rect x="569" y="385" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
 <rect x="569" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.7
+24.1
 </text>
 <text x="604" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.5%
 </text>
-<rect x="644" y="385" width="71" height="25" opacity="1" fill="#5088CE" stroke="none"/>
+<rect x="644" y="385" width="71" height="25" opacity="1" fill="#4573AE" stroke="none"/>
 <rect x="644" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="679" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-47.0
+<text x="679" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+49.9
 </text>
-<text x="679" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.2%
+<text x="679" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.2%
 </text>
-<rect x="719" y="385" width="71" height="25" opacity="1" fill="#528CD4" stroke="none"/>
+<rect x="719" y="385" width="71" height="25" opacity="1" fill="#4A7CBC" stroke="none"/>
 <rect x="719" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-48.6
+55.6
 </text>
 <text x="754" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-8.1%
++/-1.3%
 </text>
-<rect x="802" y="385" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
-<rect x="802" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="802" y="385" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
 <text x="837" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.0
+9.5
 </text>
 <text x="837" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.4%
 </text>
-<rect x="877" y="385" width="71" height="25" opacity="1" fill="#3B6192" stroke="none"/>
+<rect x="877" y="385" width="71" height="25" opacity="1" fill="#2B4264" stroke="none"/>
 <rect x="877" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.1
+20.7
 </text>
 <text x="912" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.8%
 </text>
-<rect x="952" y="385" width="71" height="25" opacity="1" fill="#4D81C4" stroke="none"/>
+<rect x="952" y="385" width="71" height="25" opacity="1" fill="#3B6091" stroke="none"/>
 <rect x="952" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-43.8
+<text x="987" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+38.5
 </text>
-<text x="987" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.7%
+<text x="987" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.4%
 </text>
-<rect x="1027" y="385" width="71" height="25" opacity="1" fill="#5DA0F3" stroke="none"/>
+<rect x="1027" y="385" width="71" height="25" opacity="1" fill="#5A99E8" stroke="none"/>
 <rect x="1027" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-57.9
+72.8
 </text>
 <text x="1062" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.6%
++/-1.1%
 </text>
-<rect x="1110" y="385" width="71" height="25" opacity="1" fill="#2D476B" stroke="none"/>
-<rect x="1110" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="1110" y="385" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="1145" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.6
+7.5
 </text>
 <text x="1145" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-0.3%
 </text>
-<rect x="1185" y="385" width="71" height="25" opacity="1" fill="#304C73" stroke="none"/>
+<rect x="1185" y="385" width="71" height="25" opacity="1" fill="#243753" stroke="none"/>
 <rect x="1185" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.8
+13.9
 </text>
 <text x="1220" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
++/-1.2%
 </text>
-<rect x="1260" y="385" width="71" height="25" opacity="1" fill="#4470AA" stroke="none"/>
+<rect x="1260" y="385" width="71" height="25" opacity="1" fill="#33527C" stroke="none"/>
 <rect x="1260" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-36.3
+30.1
 </text>
 <text x="1295" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-1.8%
 </text>
-<rect x="1335" y="385" width="71" height="25" opacity="1" fill="#5897E4" stroke="none"/>
+<rect x="1335" y="385" width="71" height="25" opacity="1" fill="#4A7DBD" stroke="none"/>
 <rect x="1335" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-53.5
+55.7
 </text>
 <text x="1370" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.7%
++/-2.6%
 </text>
 <text x="28" y="426" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="414" width="71" height="25" opacity="1" fill="#4C81C3" stroke="none"/>
+<rect x="186" y="414" width="71" height="25" opacity="1" fill="#3B6193" stroke="none"/>
 <rect x="186" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="221" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-43.6
+<text x="221" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+39.0
 </text>
-<text x="221" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.0%
+<text x="221" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
 </text>
-<rect x="261" y="414" width="71" height="25" opacity="1" fill="#2F4B71" stroke="none"/>
+<rect x="261" y="414" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
 <text x="296" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.4
+19.6
 </text>
 <text x="296" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-20.6%
++/-25.1%
 </text>
-<rect x="336" y="414" width="71" height="25" opacity="1" fill="#253754" stroke="none"/>
+<rect x="336" y="414" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
 <text x="371" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10.6
 </text>
 <text x="371" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-1.3%
 </text>
-<rect x="411" y="414" width="71" height="25" opacity="1" fill="#243651" stroke="none"/>
+<rect x="411" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
 <text x="446" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.7
 </text>
 <text x="446" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-0.2%
 </text>
-<rect x="494" y="414" width="71" height="25" opacity="1" fill="#406BA1" stroke="none"/>
+<rect x="494" y="414" width="71" height="25" opacity="1" fill="#32517A" stroke="none"/>
 <rect x="494" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.7
+29.3
 </text>
 <text x="529" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.4%
++/-9.6%
 </text>
-<rect x="569" y="414" width="71" height="25" opacity="1" fill="#34537D" stroke="none"/>
+<rect x="569" y="414" width="71" height="25" opacity="1" fill="#2C4568" stroke="none"/>
 <text x="604" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.9
+22.2
 </text>
 <text x="604" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
-</text>
-<rect x="644" y="414" width="71" height="25" opacity="1" fill="#263A57" stroke="none"/>
-<text x="679" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.7
-</text>
-<text x="679" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="719" y="414" width="71" height="25" opacity="1" fill="#23354F" stroke="none"/>
-<text x="754" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.4
-</text>
-<text x="754" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
-</text>
-<rect x="802" y="414" width="71" height="25" opacity="1" fill="#253854" stroke="none"/>
-<text x="837" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.7
-</text>
-<text x="837" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="877" y="414" width="71" height="25" opacity="1" fill="#253956" stroke="none"/>
-<text x="912" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.1
-</text>
-<text x="912" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
-</text>
-<rect x="952" y="414" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
-<text x="987" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14.5
-</text>
-<text x="987" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-18.5%
-</text>
-<rect x="1027" y="414" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
-<text x="1062" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.9
-</text>
-<text x="1062" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.1%
-</text>
-<rect x="1110" y="414" width="71" height="25" opacity="1" fill="#243651" stroke="none"/>
-<text x="1145" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
-</text>
-<text x="1145" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
-</text>
-<rect x="1185" y="414" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
-<text x="1220" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.5
-</text>
-<text x="1220" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-6.9%
 </text>
-<rect x="1260" y="414" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
-<text x="1295" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="644" y="414" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<text x="679" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.1
+</text>
+<text x="679" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
+</text>
+<rect x="719" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<text x="754" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.7
+</text>
+<text x="754" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.7%
+</text>
+<rect x="802" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<rect x="802" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="837" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.3
+</text>
+<text x="837" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="877" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<text x="912" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.3
+</text>
+<text x="912" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="952" y="414" width="71" height="25" opacity="1" fill="#243551" stroke="none"/>
+<text x="987" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.9
+</text>
+<text x="987" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.2%
+</text>
+<rect x="1027" y="414" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<text x="1062" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.2
+</text>
+<text x="1062" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.7%
+</text>
+<rect x="1110" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<rect x="1110" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1145" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.5
+</text>
+<text x="1145" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.2%
+</text>
+<rect x="1185" y="414" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<text x="1220" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.9
 </text>
-<text x="1295" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.3%
+<text x="1220" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
 </text>
-<rect x="1335" y="414" width="71" height="25" opacity="1" fill="#243752" stroke="none"/>
+<rect x="1260" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<text x="1295" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.4
+</text>
+<text x="1295" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-14.8%
+</text>
+<rect x="1335" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
 <text x="1370" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.2
+10.3
 </text>
 <text x="1370" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.5%
++/-5.2%
 </text>
 <text x="28" y="455" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="443" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<rect x="186" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="221" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.0
+5.9
 </text>
 <text x="221" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
++/-2.0%
 </text>
-<rect x="261" y="443" width="71" height="25" opacity="1" fill="#1F2C42" stroke="none"/>
+<rect x="261" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="296" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.4
+6.1
 </text>
 <text x="296" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.1%
++/-1.1%
 </text>
-<rect x="336" y="443" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="336" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="371" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.8
+2.9
 </text>
 <text x="371" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-8.6%
 </text>
-<rect x="411" y="443" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
+<rect x="411" y="443" width="71" height="25" opacity="1" fill="#182131" stroke="none"/>
 <text x="446" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
+0.4
 </text>
 <text x="446" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.4%
++/-3.5%
 </text>
 <rect x="494" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="529" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.6
+6.0
 </text>
 <text x="529" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.1%
 </text>
-<rect x="569" y="443" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<rect x="569" y="443" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="604" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 5.6
 </text>
 <text x="604" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.1%
++/-1.1%
 </text>
-<rect x="644" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="644" y="443" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
 <text x="679" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+4.7
 </text>
 <text x="679" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.2%
++/-1.4%
 </text>
-<rect x="719" y="443" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
+<rect x="719" y="443" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="754" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
+2.1
 </text>
 <text x="754" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
++/-21.8%
 </text>
-<rect x="802" y="443" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="802" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="837" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.7
-</text>
-<text x="837" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
-</text>
-<rect x="877" y="443" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="912" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
-</text>
-<text x="912" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
-</text>
-<rect x="952" y="443" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
-<text x="987" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.0
-</text>
-<text x="987" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.4%
-</text>
-<rect x="1027" y="443" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
-<text x="1062" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2.8
 </text>
+<text x="837" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.6%
+</text>
+<rect x="877" y="443" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
+<text x="912" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.7
+</text>
+<text x="912" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.8%
+</text>
+<rect x="952" y="443" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
+<text x="987" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.3
+</text>
+<text x="987" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.8%
+</text>
+<rect x="1027" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="1062" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.9
+</text>
 <text x="1062" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
-</text>
-<rect x="1110" y="443" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
-<text x="1145" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.2
-</text>
-<text x="1145" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
-</text>
-<rect x="1185" y="443" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="1220" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
-</text>
-<text x="1220" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.7%
-</text>
-<rect x="1260" y="443" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
-<text x="1295" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.3
-</text>
-<text x="1295" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.9%
 </text>
-<rect x="1335" y="443" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="1110" y="443" width="71" height="25" opacity="1" fill="#182131" stroke="none"/>
+<text x="1145" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.3
+</text>
+<text x="1145" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-11.8%
+</text>
+<rect x="1185" y="443" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
+<text x="1220" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.7
+</text>
+<text x="1220" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-13.8%
+</text>
+<rect x="1260" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<text x="1295" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.0
+</text>
+<text x="1295" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.6%
+</text>
+<rect x="1335" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="1370" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
+2.9
 </text>
 <text x="1370" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-2.6%
 </text>
 <text x="28" y="484" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="472" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="186" y="472" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
 <text x="221" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.7
+10.4
 </text>
 <text x="221" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-44.8%
++/-11.1%
 </text>
-<rect x="261" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
+<rect x="261" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="296" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
+4.1
 </text>
 <text x="296" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.5%
++/-20.7%
 </text>
-<rect x="336" y="472" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<rect x="336" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="371" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
+4.5
 </text>
 <text x="371" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-12.3%
++/-13.3%
 </text>
-<rect x="411" y="472" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="411" y="472" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="446" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.0
+2.9
 </text>
 <text x="446" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.4%
++/-19.8%
 </text>
-<rect x="494" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="494" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="529" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
+2.0
 </text>
 <text x="529" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-19.3%
++/-7.6%
 </text>
-<rect x="569" y="472" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<rect x="569" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="604" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.2
+4.5
 </text>
 <text x="604" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-23.8%
++/-53.7%
 </text>
-<rect x="644" y="472" width="71" height="25" opacity="1" fill="#1C283D" stroke="none"/>
+<rect x="644" y="472" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
 <text x="679" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
+6.2
 </text>
 <text x="679" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-75.6%
++/-16.4%
 </text>
-<rect x="719" y="472" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<rect x="719" y="472" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
 <text x="754" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.9
+5.1
 </text>
 <text x="754" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.5%
++/-21.8%
 </text>
-<rect x="802" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="802" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="837" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
+1.8
 </text>
 <text x="837" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-27.7%
++/-14.2%
 </text>
-<rect x="877" y="472" width="71" height="25" opacity="1" fill="#1C263A" stroke="none"/>
+<rect x="877" y="472" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
 <text x="912" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
+3.4
 </text>
 <text x="912" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-72.2%
++/-14.2%
 </text>
-<rect x="952" y="472" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<rect x="952" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="987" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.1
-</text>
-<text x="987" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
-</text>
-<rect x="1027" y="472" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
-<text x="1062" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.8
-</text>
-<text x="1062" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-30.8%
-</text>
-<rect x="1110" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
-<text x="1145" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
-</text>
-<text x="1145" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.7%
-</text>
-<rect x="1185" y="472" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="1220" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
-</text>
-<text x="1220" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-11.4%
-</text>
-<rect x="1260" y="472" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="1295" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.4
 </text>
-<text x="1295" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.8%
+<text x="987" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-30.9%
 </text>
-<rect x="1335" y="472" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="1027" y="472" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="1062" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.1
+</text>
+<text x="1062" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="1110" y="472" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<text x="1145" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.2
+</text>
+<text x="1145" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.9%
+</text>
+<rect x="1185" y="472" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="1220" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.9
+</text>
+<text x="1220" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-11.2%
+</text>
+<rect x="1260" y="472" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
+<text x="1295" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.1
+</text>
+<text x="1295" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-15.0%
+</text>
+<rect x="1335" y="472" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="1370" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.9
+7.4
 </text>
 <text x="1370" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-11.5%
++/-6.3%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,529 1416,529 "/>
 <text x="720" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes256 (256 B); median M items/s (+/- MAD); color scale 0-30; white outline = winner
+bytes256 (256 B); median M items/s (+/- MAD); color scale 0-50; white outline = winner
 </text>
 <text x="172" y="569" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 producer threads
@@ -1179,478 +1179,478 @@ implementation
 <text x="28" y="633" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="621" width="71" height="25" opacity="1" fill="#325078" stroke="none"/>
+<rect x="186" y="621" width="71" height="25" opacity="1" fill="#243550" stroke="none"/>
 <text x="221" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.7
+8.0
 </text>
 <text x="221" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-1.1%
 </text>
-<rect x="261" y="621" width="71" height="25" opacity="1" fill="#3F689D" stroke="none"/>
+<rect x="261" y="621" width="71" height="25" opacity="1" fill="#314E75" stroke="none"/>
 <rect x="261" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.2
+17.2
 </text>
 <text x="296" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-1.8%
 </text>
-<rect x="336" y="621" width="71" height="25" opacity="1" fill="#4572AD" stroke="none"/>
+<rect x="336" y="621" width="71" height="25" opacity="1" fill="#365886" stroke="none"/>
 <rect x="336" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.6
+21.2
 </text>
 <text x="371" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.5%
-</text>
-<rect x="411" y="621" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
-<rect x="411" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="446" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.0
-</text>
-<text x="446" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.0%
 </text>
-<rect x="494" y="621" width="71" height="25" opacity="1" fill="#324F78" stroke="none"/>
+<rect x="411" y="621" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="411" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="446" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+15.2
+</text>
+<text x="446" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="494" y="621" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
 <text x="529" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.7
+6.8
 </text>
 <text x="529" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.2%
 </text>
-<rect x="569" y="621" width="71" height="25" opacity="1" fill="#3E679C" stroke="none"/>
+<rect x="569" y="621" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
 <rect x="569" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 16.0
 </text>
 <text x="604" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-0.2%
 </text>
-<rect x="644" y="621" width="71" height="25" opacity="1" fill="#5692DD" stroke="none"/>
+<rect x="644" y="621" width="71" height="25" opacity="1" fill="#4878B6" stroke="none"/>
 <rect x="644" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="679" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-25.7
+<text x="679" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+33.3
 </text>
-<text x="679" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.5%
+<text x="679" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.5%
 </text>
-<rect x="719" y="621" width="71" height="25" opacity="1" fill="#5A9AE9" stroke="none"/>
+<rect x="719" y="621" width="71" height="25" opacity="1" fill="#4A7CBC" stroke="none"/>
 <rect x="719" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-27.4
+34.8
 </text>
 <text x="754" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-3.6%
-</text>
-<rect x="802" y="621" width="71" height="25" opacity="1" fill="#314F77" stroke="none"/>
-<rect x="802" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="837" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.5
-</text>
-<text x="837" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="877" y="621" width="71" height="25" opacity="1" fill="#3E679B" stroke="none"/>
-<rect x="877" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="912" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.9
-</text>
-<text x="912" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.7%
 </text>
-<rect x="952" y="621" width="71" height="25" opacity="1" fill="#4A7CBB" stroke="none"/>
+<rect x="802" y="621" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
+<text x="837" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.7
+</text>
+<text x="837" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="877" y="621" width="71" height="25" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="877" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="912" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+13.2
+</text>
+<text x="912" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.7%
+</text>
+<rect x="952" y="621" width="71" height="25" opacity="1" fill="#3B6092" stroke="none"/>
 <rect x="952" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-20.7
+<text x="987" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+24.2
 </text>
-<text x="987" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.0%
+<text x="987" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.3%
 </text>
-<rect x="1027" y="621" width="71" height="25" opacity="1" fill="#5A9AEA" stroke="none"/>
+<rect x="1027" y="621" width="71" height="25" opacity="1" fill="#5692DD" stroke="none"/>
 <rect x="1027" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-27.6
+42.9
 </text>
 <text x="1062" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-3.3%
++/-0.8%
 </text>
-<rect x="1110" y="621" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<rect x="1110" y="621" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
 <text x="1145" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.4
+6.6
 </text>
 <text x="1145" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-2.4%
 </text>
-<rect x="1185" y="621" width="71" height="25" opacity="1" fill="#2A4264" stroke="none"/>
+<rect x="1185" y="621" width="71" height="25" opacity="1" fill="#243551" stroke="none"/>
 <text x="1220" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.7
+8.1
 </text>
 <text x="1220" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-15.5%
 </text>
-<rect x="1260" y="621" width="71" height="25" opacity="1" fill="#3E679B" stroke="none"/>
+<rect x="1260" y="621" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
 <rect x="1260" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.9
+15.7
 </text>
 <text x="1295" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-1.9%
 </text>
-<rect x="1335" y="621" width="71" height="25" opacity="1" fill="#4F86CB" stroke="none"/>
+<rect x="1335" y="621" width="71" height="25" opacity="1" fill="#4879B7" stroke="none"/>
 <rect x="1335" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1370" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-23.0
+<text x="1370" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+33.3
 </text>
-<text x="1370" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-2.1%
+<text x="1370" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.6%
 </text>
 <text x="28" y="662" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="650" width="71" height="25" opacity="1" fill="#5A9AE9" stroke="none"/>
+<rect x="186" y="650" width="71" height="25" opacity="1" fill="#3C6396" stroke="none"/>
 <rect x="186" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="221" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-27.5
+<text x="221" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+25.2
 </text>
-<text x="221" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.2%
+<text x="221" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.6%
 </text>
-<rect x="261" y="650" width="71" height="25" opacity="1" fill="#33537D" stroke="none"/>
+<rect x="261" y="650" width="71" height="25" opacity="1" fill="#283E5D" stroke="none"/>
 <text x="296" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.4
+11.2
 </text>
 <text x="296" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.5%
++/-2.9%
 </text>
-<rect x="336" y="650" width="71" height="25" opacity="1" fill="#314E76" stroke="none"/>
+<rect x="336" y="650" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
 <text x="371" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.3
+10.5
 </text>
 <text x="371" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.1%
 </text>
-<rect x="411" y="650" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
+<rect x="411" y="650" width="71" height="25" opacity="1" fill="#253956" stroke="none"/>
 <text x="446" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.6
-</text>
-<text x="446" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
-</text>
-<rect x="494" y="650" width="71" height="25" opacity="1" fill="#426EA7" stroke="none"/>
-<rect x="494" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="529" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.7
-</text>
-<text x="529" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.8%
-</text>
-<rect x="569" y="650" width="71" height="25" opacity="1" fill="#3A5F8F" stroke="none"/>
-<text x="604" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14.1
-</text>
-<text x="604" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.1%
-</text>
-<rect x="644" y="650" width="71" height="25" opacity="1" fill="#314E77" stroke="none"/>
-<text x="679" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.5
-</text>
-<text x="679" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.3%
-</text>
-<rect x="719" y="650" width="71" height="25" opacity="1" fill="#2E496E" stroke="none"/>
-<text x="754" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.2
-</text>
-<text x="754" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.6%
-</text>
-<rect x="802" y="650" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
-<text x="837" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.5
-</text>
-<text x="837" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
-</text>
-<rect x="877" y="650" width="71" height="25" opacity="1" fill="#2E496E" stroke="none"/>
-<text x="912" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.2
-</text>
-<text x="912" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="952" y="650" width="71" height="25" opacity="1" fill="#2E496E" stroke="none"/>
-<text x="987" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.2
-</text>
-<text x="987" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="1027" y="650" width="71" height="25" opacity="1" fill="#2D476B" stroke="none"/>
-<text x="1062" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.8
-</text>
-<text x="1062" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
-</text>
-<rect x="1110" y="650" width="71" height="25" opacity="1" fill="#2E496E" stroke="none"/>
-<rect x="1110" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1145" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.3
 </text>
-<text x="1145" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
+<text x="446" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
 </text>
-<rect x="1185" y="650" width="71" height="25" opacity="1" fill="#2C4669" stroke="none"/>
+<rect x="494" y="650" width="71" height="25" opacity="1" fill="#304C73" stroke="none"/>
+<rect x="494" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="529" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16.6
+</text>
+<text x="529" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.0%
+</text>
+<rect x="569" y="650" width="71" height="25" opacity="1" fill="#294060" stroke="none"/>
+<text x="604" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.9
+</text>
+<text x="604" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.9%
+</text>
+<rect x="644" y="650" width="71" height="25" opacity="1" fill="#273C5A" stroke="none"/>
+<text x="679" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.4
+</text>
+<text x="679" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.7%
+</text>
+<rect x="719" y="650" width="71" height="25" opacity="1" fill="#243753" stroke="none"/>
+<text x="754" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.6
+</text>
+<text x="754" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="802" y="650" width="71" height="25" opacity="1" fill="#263A58" stroke="none"/>
+<rect x="802" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="837" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.8
+</text>
+<text x="837" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="877" y="650" width="71" height="25" opacity="1" fill="#253753" stroke="none"/>
+<text x="912" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.8
+</text>
+<text x="912" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.3%
+</text>
+<rect x="952" y="650" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
+<text x="987" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.7
+</text>
+<text x="987" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.9%
+</text>
+<rect x="1027" y="650" width="71" height="25" opacity="1" fill="#243652" stroke="none"/>
+<text x="1062" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.4
+</text>
+<text x="1062" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.3%
+</text>
+<rect x="1110" y="650" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<rect x="1110" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1145" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.2
+</text>
+<text x="1145" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="1185" y="650" width="71" height="25" opacity="1" fill="#253854" stroke="none"/>
 <rect x="1185" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.5
+8.9
 </text>
 <text x="1220" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.6%
++/-2.0%
 </text>
-<rect x="1260" y="650" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="1260" y="650" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
 <text x="1295" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.0
+9.1
 </text>
 <text x="1295" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-4.1%
 </text>
-<rect x="1335" y="650" width="71" height="25" opacity="1" fill="#2F4B71" stroke="none"/>
+<rect x="1335" y="650" width="71" height="25" opacity="1" fill="#263A57" stroke="none"/>
 <text x="1370" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
+9.6
 </text>
 <text x="1370" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.6%
++/-0.6%
 </text>
 <text x="28" y="691" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="679" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
+<rect x="186" y="679" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
 <text x="221" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+4.2
 </text>
 <text x="221" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-9.2%
 </text>
-<rect x="261" y="679" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<rect x="261" y="679" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="296" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.8
+4.1
 </text>
 <text x="296" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.6%
++/-1.3%
 </text>
-<rect x="336" y="679" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<rect x="336" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="371" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
+2.0
 </text>
 <text x="371" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.7%
++/-6.5%
 </text>
-<rect x="411" y="679" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="411" y="679" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
 <text x="446" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.0
+0.4
 </text>
 <text x="446" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.0%
++/-0.7%
 </text>
-<rect x="494" y="679" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<rect x="494" y="679" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="529" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
+4.0
 </text>
 <text x="529" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.7%
++/-2.2%
 </text>
-<rect x="569" y="679" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
+<rect x="569" y="679" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="604" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.0
 </text>
 <text x="604" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.1%
++/-1.0%
 </text>
-<rect x="644" y="679" width="71" height="25" opacity="1" fill="#202E45" stroke="none"/>
+<rect x="644" y="679" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
 <text x="679" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 3.2
 </text>
 <text x="679" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.5%
-</text>
-<rect x="719" y="679" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="754" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
-</text>
-<text x="754" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.1%
-</text>
-<rect x="802" y="679" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="837" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
-</text>
-<text x="837" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="877" y="679" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
-<text x="912" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
-</text>
-<text x="912" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
-</text>
-<rect x="952" y="679" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
-<text x="987" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
-</text>
-<text x="987" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.5%
-</text>
-<rect x="1027" y="679" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
-<text x="1062" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
-</text>
-<text x="1062" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.5%
-</text>
-<rect x="1110" y="679" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="1145" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.7
-</text>
-<text x="1145" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.1%
-</text>
-<rect x="1185" y="679" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
-<text x="1220" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.5
-</text>
-<text x="1220" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.2%
 </text>
-<rect x="1260" y="679" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
-<text x="1295" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
+<rect x="719" y="679" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
+<text x="754" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.1
 </text>
-<text x="1295" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
+<text x="754" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.9%
 </text>
-<rect x="1335" y="679" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
-<text x="1370" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="802" y="679" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="837" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.8
+</text>
+<text x="837" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.7%
+</text>
+<rect x="877" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="912" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 1.9
 </text>
+<text x="912" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.2%
+</text>
+<rect x="952" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="987" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.9
+</text>
+<text x="987" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-14.6%
+</text>
+<rect x="1027" y="679" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="1062" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.8
+</text>
+<text x="1062" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="1110" y="679" width="71" height="25" opacity="1" fill="#192131" stroke="none"/>
+<text x="1145" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.4
+</text>
+<text x="1145" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-39.7%
+</text>
+<rect x="1185" y="679" width="71" height="25" opacity="1" fill="#192131" stroke="none"/>
+<text x="1220" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.4
+</text>
+<text x="1220" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-14.5%
+</text>
+<rect x="1260" y="679" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
+<text x="1295" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.6
+</text>
+<text x="1295" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.9%
+</text>
+<rect x="1335" y="679" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<text x="1370" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.6
+</text>
 <text x="1370" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-6.2%
 </text>
 <text x="28" y="720" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="708" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
+<rect x="186" y="708" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
 <text x="221" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.3
+5.4
 </text>
 <text x="221" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.9%
++/-5.4%
 </text>
-<rect x="261" y="708" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<rect x="261" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="296" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
-</text>
-<text x="296" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.7%
-</text>
-<rect x="336" y="708" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
-<text x="371" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
-</text>
-<text x="371" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.5%
-</text>
-<rect x="411" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="446" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
-</text>
-<text x="446" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.2%
-</text>
-<rect x="494" y="708" width="71" height="25" opacity="1" fill="#243752" stroke="none"/>
-<text x="529" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.1
-</text>
-<text x="529" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.6%
-</text>
-<rect x="569" y="708" width="71" height="25" opacity="1" fill="#253753" stroke="none"/>
-<text x="604" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.3
-</text>
-<text x="604" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.7%
-</text>
-<rect x="644" y="708" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
-<text x="679" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 3.8
 </text>
-<text x="679" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
+<text x="296" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-13.4%
 </text>
-<rect x="719" y="708" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
-<text x="754" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
-</text>
-<text x="754" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.3%
-</text>
-<rect x="802" y="708" width="71" height="25" opacity="1" fill="#202E45" stroke="none"/>
-<text x="837" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
-</text>
-<text x="837" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.3%
-</text>
-<rect x="877" y="708" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
-<text x="912" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
-</text>
-<text x="912" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.0%
-</text>
-<rect x="952" y="708" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
-<text x="987" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.8
-</text>
-<text x="987" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.9%
-</text>
-<rect x="1027" y="708" width="71" height="25" opacity="1" fill="#213049" stroke="none"/>
-<text x="1062" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
-</text>
-<text x="1062" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.3%
-</text>
-<rect x="1110" y="708" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="1145" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="336" y="708" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="371" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2.9
 </text>
-<text x="1145" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.1%
+<text x="371" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-25.4%
 </text>
-<rect x="1185" y="708" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<rect x="411" y="708" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="446" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.4
+</text>
+<text x="446" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.1%
+</text>
+<rect x="494" y="708" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<text x="529" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.7
+</text>
+<text x="529" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.1%
+</text>
+<rect x="569" y="708" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<text x="604" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.6
+</text>
+<text x="604" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.0%
+</text>
+<rect x="644" y="708" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="679" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.1
+</text>
+<text x="679" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-9.1%
+</text>
+<rect x="719" y="708" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="754" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.0
+</text>
+<text x="754" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-31.0%
+</text>
+<rect x="802" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="837" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.7
+</text>
+<text x="837" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-24.9%
+</text>
+<rect x="877" y="708" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
+<text x="912" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.9
+</text>
+<text x="912" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.7%
+</text>
+<rect x="952" y="708" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="987" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.0
+</text>
+<text x="987" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.3%
+</text>
+<rect x="1027" y="708" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<text x="1062" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.1
+</text>
+<text x="1062" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-10.9%
+</text>
+<rect x="1110" y="708" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<text x="1145" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.6
+</text>
+<text x="1145" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-16.8%
+</text>
+<rect x="1185" y="708" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="1220" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
+3.4
 </text>
 <text x="1220" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-3.8%
 </text>
-<rect x="1260" y="708" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
+<rect x="1260" y="708" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="1295" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.4
+4.6
 </text>
 <text x="1295" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.6%
++/-3.0%
 </text>
-<rect x="1335" y="708" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<rect x="1335" y="708" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
 <text x="1370" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+5.3
 </text>
 <text x="1370" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
++/-5.7%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,765 1416,765 "/>
 <text x="720" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">

--- a/doc/charts/mpmc.svg
+++ b/doc/charts/mpmc.svg
@@ -4,10 +4,10 @@
 fanring MPMC comparison
 </text>
 <text x="720" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; blocking operations; 5 samples; nominal capacity 8192 items
+Linux VM on a 2018 Mac Mini, 6 physical cores / 12 threads, performance governor, turbo off; try operations; 5 samples; nominal capacity 8192 items
 </text>
 <text x="720" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-u64 (8 B); median M items/s (+/- MAD); color scale 0-100; white outline = winner
+u64 (8 B); median M items/s (+/- MAD); color scale 0-150; white outline = winner
 </text>
 <text x="172" y="97" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 producer threads
@@ -81,482 +81,482 @@ implementation
 <text x="28" y="161" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="149" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
+<rect x="186" y="149" width="71" height="25" opacity="1" fill="#3A5F90" stroke="none"/>
 <rect x="186" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.3
+71.4
 </text>
 <text x="221" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.8%
++/-0.5%
 </text>
-<rect x="261" y="149" width="71" height="25" opacity="1" fill="#304C72" stroke="none"/>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="#325078" stroke="none"/>
 <rect x="261" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-32.8
+53.7
 </text>
 <text x="296" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.6%
++/-4.5%
 </text>
-<rect x="336" y="149" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="336" y="149" width="71" height="25" opacity="1" fill="#375986" stroke="none"/>
 <rect x="336" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.1
+63.8
 </text>
 <text x="371" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-4.4%
 </text>
-<rect x="411" y="149" width="71" height="25" opacity="1" fill="#2A4264" stroke="none"/>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="#2D476B" stroke="none"/>
 <rect x="411" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.7
+43.9
 </text>
 <text x="446" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
++/-24.4%
 </text>
-<rect x="494" y="149" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<rect x="494" y="149" width="71" height="25" opacity="1" fill="#3A5F8F" stroke="none"/>
+<rect x="494" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.2
+70.7
 </text>
 <text x="529" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
-</text>
-<rect x="569" y="149" width="71" height="25" opacity="1" fill="#345480" stroke="none"/>
-<rect x="569" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="604" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-39.5
-</text>
-<text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="#497BBA" stroke="none"/>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-68.5
-</text>
-<text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.7%
 </text>
-<rect x="719" y="149" width="71" height="25" opacity="1" fill="#426DA5" stroke="none"/>
+<rect x="569" y="149" width="71" height="25" opacity="1" fill="#34537E" stroke="none"/>
+<rect x="569" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="604" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+57.8
+</text>
+<text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4B7DBE" stroke="none"/>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+105.3
+</text>
+<text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.6%
+</text>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="#4B7DBE" stroke="none"/>
 <rect x="719" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-57.9
+<text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+105.4
 </text>
-<text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
+<text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-3.1%
 </text>
-<rect x="802" y="149" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="802" y="149" width="71" height="25" opacity="1" fill="#3A5E8E" stroke="none"/>
+<rect x="802" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="837" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.7
+70.1
 </text>
 <text x="837" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-1.4%
 </text>
-<rect x="877" y="149" width="71" height="25" opacity="1" fill="#2F4B72" stroke="none"/>
+<rect x="877" y="149" width="71" height="25" opacity="1" fill="#34537D" stroke="none"/>
 <rect x="877" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-32.6
+57.4
 </text>
 <text x="912" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-1.1%
 </text>
-<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4471AA" stroke="none"/>
+<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4370A9" stroke="none"/>
 <rect x="952" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="987" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-60.6
+90.0
 </text>
 <text x="987" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-3.2%
 </text>
-<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5DA0F2" stroke="none"/>
+<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5794E0" stroke="none"/>
 <rect x="1027" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-96.1
+130.4
 </text>
 <text x="1062" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-3.3%
++/-0.8%
 </text>
-<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#3A5E8E" stroke="none"/>
+<rect x="1110" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1145" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.6
+70.0
 </text>
 <text x="1145" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-1.2%
 </text>
-<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#243752" stroke="none"/>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <rect x="1185" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.9
+36.1
 </text>
 <text x="1220" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-9.1%
 </text>
-<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#355580" stroke="none"/>
+<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#3B6091" stroke="none"/>
 <rect x="1260" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-39.8
+72.2
 </text>
 <text x="1295" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.5%
++/-1.1%
 </text>
-<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#4E83C7" stroke="none"/>
+<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#4C81C3" stroke="none"/>
 <rect x="1335" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-74.5
+109.3
 </text>
 <text x="1370" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.9%
++/-2.9%
 </text>
 <text x="28" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="178" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="186" y="178" width="71" height="25" opacity="1" fill="#203048" stroke="none"/>
 <text x="221" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.8
+17.6
 </text>
 <text x="221" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
++/-1.7%
 </text>
-<rect x="261" y="178" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<rect x="261" y="178" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="296" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.5
+13.8
 </text>
 <text x="296" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.0%
-</text>
-<rect x="336" y="178" width="71" height="25" opacity="1" fill="#1F2E45" stroke="none"/>
-<text x="371" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.4
-</text>
-<text x="371" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
-</text>
-<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1F2C42" stroke="none"/>
-<text x="446" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.1
-</text>
-<text x="446" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.8%
-</text>
-<rect x="494" y="178" width="71" height="25" opacity="1" fill="#314E75" stroke="none"/>
-<rect x="494" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="529" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.3
-</text>
-<text x="529" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-23.1%
-</text>
-<rect x="569" y="178" width="71" height="25" opacity="1" fill="#243752" stroke="none"/>
-<text x="604" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.1
-</text>
-<text x="604" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.5%
-</text>
-<rect x="644" y="178" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
-<text x="679" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.7
-</text>
-<text x="679" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.7%
 </text>
-<rect x="719" y="178" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
-<text x="754" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.0
-</text>
-<text x="754" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="802" y="178" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
-<rect x="802" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="837" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.1
-</text>
-<text x="837" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.6%
-</text>
-<rect x="877" y="178" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
-<text x="912" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.0
-</text>
-<text x="912" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
-</text>
-<rect x="952" y="178" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
-<text x="987" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.0
-</text>
-<text x="987" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-17.6%
-</text>
-<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
-<text x="1062" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="336" y="178" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="371" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10.9
 </text>
-<text x="1062" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="371" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.3%
+</text>
+<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="446" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.3
+</text>
+<text x="446" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-6.8%
 </text>
-<rect x="1110" y="178" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
-<rect x="1110" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="494" y="178" width="71" height="25" opacity="1" fill="#283D5C" stroke="none"/>
+<text x="529" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+32.9
+</text>
+<text x="529" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="569" y="178" width="71" height="25" opacity="1" fill="#21324B" stroke="none"/>
+<text x="604" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.8
+</text>
+<text x="604" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-11.4%
+</text>
+<rect x="644" y="178" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<text x="679" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.1
+</text>
+<text x="679" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.0%
+</text>
+<rect x="719" y="178" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="754" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.0
+</text>
+<text x="754" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.2%
+</text>
+<rect x="802" y="178" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<text x="837" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+17.9
+</text>
+<text x="837" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.3%
+</text>
+<rect x="877" y="178" width="71" height="25" opacity="1" fill="#22334C" stroke="none"/>
+<text x="912" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+21.0
+</text>
+<text x="912" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.4%
+</text>
+<rect x="952" y="178" width="71" height="25" opacity="1" fill="#21324B" stroke="none"/>
+<text x="987" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.8
+</text>
+<text x="987" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-9.0%
+</text>
+<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
+<text x="1062" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.5
+</text>
+<text x="1062" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.4%
+</text>
+<rect x="1110" y="178" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="1145" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.7
+13.9
 </text>
 <text x="1145" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.5%
++/-17.7%
 </text>
-<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="1220" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.6
+11.9
 </text>
 <text x="1220" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-6.7%
 </text>
-<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="1295" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
+12.0
 </text>
 <text x="1295" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
++/-2.9%
 </text>
-<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#1F2C42" stroke="none"/>
 <text x="1370" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.1
+13.7
 </text>
 <text x="1370" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.7%
++/-8.9%
 </text>
 <text x="28" y="219" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="207" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
+<rect x="186" y="207" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="221" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.9
 </text>
 <text x="221" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.1%
++/-2.9%
 </text>
-<rect x="261" y="207" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="261" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="296" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.4
-</text>
-<text x="296" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
-</text>
-<rect x="336" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="371" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.1
-</text>
-<text x="371" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.7%
-</text>
-<rect x="411" y="207" width="71" height="25" opacity="1" fill="#182031" stroke="none"/>
-<text x="446" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.3
-</text>
-<text x="446" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
-</text>
-<rect x="494" y="207" width="71" height="25" opacity="1" fill="#1E2A3F" stroke="none"/>
-<text x="529" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.7
-</text>
-<text x="529" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="569" y="207" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
-<text x="604" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.8
 </text>
-<text x="604" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.7%
+<text x="296" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.4%
 </text>
-<rect x="644" y="207" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="336" y="207" width="71" height="25" opacity="1" fill="#1A2435" stroke="none"/>
+<text x="371" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.1
+</text>
+<text x="371" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.8%
+</text>
+<rect x="411" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<text x="446" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.0
+</text>
+<text x="446" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-17.6%
+</text>
+<rect x="494" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="529" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.5
+</text>
+<text x="529" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="569" y="207" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<text x="604" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.6
+</text>
+<text x="604" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.2%
+</text>
+<rect x="644" y="207" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="679" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 5.4
 </text>
 <text x="679" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.4%
++/-1.3%
 </text>
-<rect x="719" y="207" width="71" height="25" opacity="1" fill="#192234" stroke="none"/>
+<rect x="719" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="754" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
+2.4
 </text>
 <text x="754" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-12.9%
++/-4.6%
 </text>
-<rect x="802" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="802" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="837" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.9
+4.3
 </text>
 <text x="837" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-3.5%
 </text>
-<rect x="877" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="877" y="207" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
 <text x="912" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.9
+5.0
 </text>
 <text x="912" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-2.9%
 </text>
-<rect x="952" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="952" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="987" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.6
 </text>
 <text x="987" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.9%
++/-7.6%
 </text>
-<rect x="1027" y="207" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
+<rect x="1027" y="207" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="1062" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 3.4
 </text>
 <text x="1062" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.8%
 </text>
-<rect x="1110" y="207" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
+<rect x="1110" y="207" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
 <text x="1145" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.0
+1.8
 </text>
 <text x="1145" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.9%
++/-2.5%
 </text>
-<rect x="1185" y="207" width="71" height="25" opacity="1" fill="#192131" stroke="none"/>
+<rect x="1185" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1220" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.7
+2.4
 </text>
 <text x="1220" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-18.1%
++/-3.1%
 </text>
-<rect x="1260" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<rect x="1260" y="207" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
 <text x="1295" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.6
+3.1
 </text>
 <text x="1295" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.8%
++/-1.3%
 </text>
-<rect x="1335" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="1335" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="1370" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.1
+4.4
 </text>
 <text x="1370" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
++/-3.1%
 </text>
 <text x="28" y="248" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="236" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<rect x="186" y="236" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="221" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.9
+2.2
 </text>
 <text x="221" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.1%
++/-5.3%
 </text>
-<rect x="261" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="261" y="236" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
 <text x="296" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.8
+1.4
 </text>
 <text x="296" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-24.2%
++/-61.5%
 </text>
-<rect x="336" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="336" y="236" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
 <text x="371" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
+1.5
 </text>
 <text x="371" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-29.0%
++/-21.1%
 </text>
 <rect x="411" y="236" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="446" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.4
+3.6
 </text>
 <text x="446" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.9%
++/-3.4%
 </text>
-<rect x="494" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="494" y="236" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="529" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.8
+2.3
 </text>
 <text x="529" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.2%
++/-10.2%
 </text>
-<rect x="569" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="569" y="236" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="604" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
+2.5
 </text>
 <text x="604" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-19.4%
++/-9.9%
 </text>
-<rect x="644" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<rect x="644" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="679" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.2
+4.7
 </text>
 <text x="679" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.7%
++/-14.0%
 </text>
-<rect x="719" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="719" y="236" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
 <text x="754" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.0
+6.2
 </text>
 <text x="754" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.1%
++/-11.7%
 </text>
-<rect x="802" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="802" y="236" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="837" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
+2.2
 </text>
 <text x="837" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.6%
++/-27.1%
 </text>
-<rect x="877" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="877" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="912" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
-</text>
-<text x="912" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.2%
-</text>
-<rect x="952" y="236" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="987" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.5
-</text>
-<text x="987" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-12.1%
-</text>
-<rect x="1027" y="236" width="71" height="25" opacity="1" fill="#1C283B" stroke="none"/>
-<text x="1062" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.7
-</text>
-<text x="1062" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.0%
-</text>
-<rect x="1110" y="236" width="71" height="25" opacity="1" fill="#192234" stroke="none"/>
-<text x="1145" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
-</text>
-<text x="1145" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.1%
-</text>
-<rect x="1185" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
-<text x="1220" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.0
-</text>
-<text x="1220" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.6%
-</text>
-<rect x="1260" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
-<text x="1295" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.9
-</text>
-<text x="1295" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
-</text>
-<rect x="1335" y="236" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="1370" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 5.9
 </text>
+<text x="912" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-20.1%
+</text>
+<rect x="952" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="987" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.0
+</text>
+<text x="987" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.0%
+</text>
+<rect x="1027" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="1062" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.1
+</text>
+<text x="1062" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.0%
+</text>
+<rect x="1110" y="236" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
+<text x="1145" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.7
+</text>
+<text x="1145" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-17.1%
+</text>
+<rect x="1185" y="236" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
+<text x="1220" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.3
+</text>
+<text x="1220" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-26.7%
+</text>
+<rect x="1260" y="236" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<text x="1295" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.2
+</text>
+<text x="1295" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-15.5%
+</text>
+<rect x="1335" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<text x="1370" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.8
+</text>
 <text x="1370" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.9%
++/-7.2%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,293 1416,293 "/>
 <text x="720" y="309" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes64 (64 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner
+bytes64 (64 B); median M items/s (+/- MAD); color scale 0-100; white outline = winner
 </text>
 <text x="172" y="333" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 producer threads
@@ -630,482 +630,482 @@ implementation
 <text x="28" y="397" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="385" width="71" height="25" opacity="1" fill="#23354F" stroke="none"/>
+<rect x="186" y="385" width="71" height="25" opacity="1" fill="#2B4264" stroke="none"/>
 <text x="221" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.4
+25.9
 </text>
 <text x="221" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.1%
 </text>
-<rect x="261" y="385" width="71" height="25" opacity="1" fill="#314E76" stroke="none"/>
+<rect x="261" y="385" width="71" height="25" opacity="1" fill="#304D74" stroke="none"/>
 <rect x="261" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-27.6
+33.8
 </text>
 <text x="296" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-0.3%
 </text>
-<rect x="336" y="385" width="71" height="25" opacity="1" fill="#33537D" stroke="none"/>
+<rect x="336" y="385" width="71" height="25" opacity="1" fill="#3A5F8F" stroke="none"/>
 <rect x="336" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.5
+47.1
 </text>
 <text x="371" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
++/-11.4%
 </text>
-<rect x="411" y="385" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="411" y="385" width="71" height="25" opacity="1" fill="#314D75" stroke="none"/>
 <rect x="411" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.2
+34.0
 </text>
 <text x="446" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.3%
++/-25.0%
 </text>
-<rect x="494" y="385" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="494" y="385" width="71" height="25" opacity="1" fill="#2B4264" stroke="none"/>
 <text x="529" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.0
+25.8
 </text>
 <text x="529" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.2%
 </text>
-<rect x="569" y="385" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="569" y="385" width="71" height="25" opacity="1" fill="#314E76" stroke="none"/>
 <rect x="569" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.1
+34.4
 </text>
 <text x="604" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="644" y="385" width="71" height="25" opacity="1" fill="#4573AE" stroke="none"/>
-<rect x="644" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="679" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-49.9
-</text>
-<text x="679" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.2%
-</text>
-<rect x="719" y="385" width="71" height="25" opacity="1" fill="#4A7CBC" stroke="none"/>
-<rect x="719" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="754" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-55.6
-</text>
-<text x="754" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.3%
-</text>
-<rect x="802" y="385" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
-<text x="837" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.5
-</text>
-<text x="837" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="877" y="385" width="71" height="25" opacity="1" fill="#2B4264" stroke="none"/>
-<rect x="877" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="912" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-20.7
-</text>
-<text x="912" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
-</text>
-<rect x="952" y="385" width="71" height="25" opacity="1" fill="#3B6091" stroke="none"/>
-<rect x="952" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-38.5
-</text>
-<text x="987" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="1027" y="385" width="71" height="25" opacity="1" fill="#5A99E8" stroke="none"/>
-<rect x="1027" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1062" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-72.8
-</text>
-<text x="1062" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.1%
-</text>
-<rect x="1110" y="385" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="1145" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
-</text>
-<text x="1145" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.3%
 </text>
-<rect x="1185" y="385" width="71" height="25" opacity="1" fill="#243753" stroke="none"/>
+<rect x="644" y="385" width="71" height="25" opacity="1" fill="#4777B3" stroke="none"/>
+<rect x="644" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="679" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+65.1
+</text>
+<text x="679" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="719" y="385" width="71" height="25" opacity="1" fill="#4C80C2" stroke="none"/>
+<rect x="719" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="754" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+72.3
+</text>
+<text x="754" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-14.4%
+</text>
+<rect x="802" y="385" width="71" height="25" opacity="1" fill="#2A4263" stroke="none"/>
+<rect x="802" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="837" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+25.3
+</text>
+<text x="837" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="877" y="385" width="71" height="25" opacity="1" fill="#304C72" stroke="none"/>
+<rect x="877" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="912" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+32.9
+</text>
+<text x="912" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
+</text>
+<rect x="952" y="385" width="71" height="25" opacity="1" fill="#406AA1" stroke="none"/>
+<rect x="952" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="987" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+55.9
+</text>
+<text x="987" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.3%
+</text>
+<rect x="1027" y="385" width="71" height="25" opacity="1" fill="#5B9CEC" stroke="none"/>
+<rect x="1027" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1062" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+93.2
+</text>
+<text x="1062" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-2.7%
+</text>
+<rect x="1110" y="385" width="71" height="25" opacity="1" fill="#243652" stroke="none"/>
+<rect x="1110" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1145" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16.9
+</text>
+<text x="1145" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.3%
+</text>
+<rect x="1185" y="385" width="71" height="25" opacity="1" fill="#283D5C" stroke="none"/>
 <rect x="1185" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.9
+22.0
 </text>
 <text x="1220" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
-</text>
-<rect x="1260" y="385" width="71" height="25" opacity="1" fill="#33527C" stroke="none"/>
-<rect x="1260" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1295" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.1
-</text>
-<text x="1295" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.8%
 </text>
-<rect x="1335" y="385" width="71" height="25" opacity="1" fill="#4A7DBD" stroke="none"/>
+<rect x="1260" y="385" width="71" height="25" opacity="1" fill="#375986" stroke="none"/>
+<rect x="1260" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1295" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+42.6
+</text>
+<text x="1295" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="1335" y="385" width="71" height="25" opacity="1" fill="#4F86CB" stroke="none"/>
 <rect x="1335" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-55.7
+76.7
 </text>
 <text x="1370" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-2.6%
++/-3.4%
 </text>
 <text x="28" y="426" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="414" width="71" height="25" opacity="1" fill="#3B6193" stroke="none"/>
+<rect x="186" y="414" width="71" height="25" opacity="1" fill="#385B8A" stroke="none"/>
 <rect x="186" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-39.0
+44.7
 </text>
 <text x="221" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.6%
 </text>
-<rect x="261" y="414" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="261" y="414" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
 <text x="296" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.6
+14.8
 </text>
 <text x="296" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-25.1%
++/-9.4%
 </text>
-<rect x="336" y="414" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
+<rect x="336" y="414" width="71" height="25" opacity="1" fill="#202E45" stroke="none"/>
 <text x="371" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.6
+10.5
 </text>
 <text x="371" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.3%
++/-2.5%
 </text>
-<rect x="411" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<rect x="411" y="414" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="446" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
+9.6
 </text>
 <text x="446" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.8%
 </text>
-<rect x="494" y="414" width="71" height="25" opacity="1" fill="#32517A" stroke="none"/>
+<rect x="494" y="414" width="71" height="25" opacity="1" fill="#304C72" stroke="none"/>
 <rect x="494" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.3
+32.8
 </text>
 <text x="529" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.6%
++/-0.3%
 </text>
-<rect x="569" y="414" width="71" height="25" opacity="1" fill="#2C4568" stroke="none"/>
+<rect x="569" y="414" width="71" height="25" opacity="1" fill="#283E5D" stroke="none"/>
 <text x="604" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.2
+22.3
 </text>
 <text x="604" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.9%
++/-7.8%
 </text>
-<rect x="644" y="414" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="644" y="414" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
 <text x="679" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.1
+10.8
 </text>
 <text x="679" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
++/-4.6%
 </text>
-<rect x="719" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<rect x="719" y="414" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="754" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
+9.4
 </text>
 <text x="754" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.7%
++/-2.4%
 </text>
-<rect x="802" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
-<rect x="802" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="802" y="414" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
 <text x="837" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.3
+11.1
 </text>
 <text x="837" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="877" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
-<text x="912" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.3
-</text>
-<text x="912" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="952" y="414" width="71" height="25" opacity="1" fill="#243551" stroke="none"/>
-<text x="987" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.9
-</text>
-<text x="987" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.2%
-</text>
-<rect x="1027" y="414" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
-<text x="1062" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.2
-</text>
-<text x="1062" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
-</text>
-<rect x="1110" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
-<rect x="1110" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1145" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.5
-</text>
-<text x="1145" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.2%
 </text>
-<rect x="1185" y="414" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="877" y="414" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<text x="912" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.8
+</text>
+<text x="912" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.6%
+</text>
+<rect x="952" y="414" width="71" height="25" opacity="1" fill="#243651" stroke="none"/>
+<text x="987" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16.3
+</text>
+<text x="987" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-11.0%
+</text>
+<rect x="1027" y="414" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="1062" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.8
+</text>
+<text x="1062" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="1110" y="414" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="1145" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.1
+</text>
+<text x="1145" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="1185" y="414" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
 <text x="1220" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.9
+9.9
 </text>
 <text x="1220" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-4.4%
 </text>
-<rect x="1260" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<rect x="1260" y="414" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="1295" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.4
+9.2
 </text>
 <text x="1295" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.8%
++/-1.5%
 </text>
-<rect x="1335" y="414" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<rect x="1335" y="414" width="71" height="25" opacity="1" fill="#202E45" stroke="none"/>
 <text x="1370" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.3
+10.5
 </text>
 <text x="1370" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.2%
++/-13.9%
 </text>
 <text x="28" y="455" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="186" y="443" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
 <text x="221" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.9
-</text>
-<text x="221" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
-</text>
-<rect x="261" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="296" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.1
-</text>
-<text x="296" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
-</text>
-<rect x="336" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
-<text x="371" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
-</text>
-<text x="371" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.6%
-</text>
-<rect x="411" y="443" width="71" height="25" opacity="1" fill="#182131" stroke="none"/>
-<text x="446" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.4
-</text>
-<text x="446" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.5%
-</text>
-<rect x="494" y="443" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="529" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.0
 </text>
-<text x="529" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.1%
+<text x="221" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
 </text>
-<rect x="569" y="443" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
-<text x="604" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.6
+<rect x="261" y="443" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<text x="296" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.4
 </text>
-<text x="604" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
+<text x="296" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
 </text>
-<rect x="644" y="443" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="679" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="336" y="443" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="371" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.1
+</text>
+<text x="371" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="411" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<text x="446" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.6
+</text>
+<text x="446" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-15.2%
+</text>
+<rect x="494" y="443" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="529" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.7
 </text>
+<text x="529" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.7%
+</text>
+<rect x="569" y="443" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<text x="604" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.5
+</text>
+<text x="604" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
+</text>
+<rect x="644" y="443" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<text x="679" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.8
+</text>
 <text x="679" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
++/-1.9%
 </text>
 <rect x="719" y="443" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="754" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.1
+2.3
 </text>
 <text x="754" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-21.8%
++/-13.2%
 </text>
-<rect x="802" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="802" y="443" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="837" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
+2.9
 </text>
 <text x="837" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.6%
++/-1.6%
 </text>
-<rect x="877" y="443" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
+<rect x="877" y="443" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="912" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.7
+3.7
 </text>
 <text x="912" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.8%
++/-2.6%
 </text>
-<rect x="952" y="443" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
+<rect x="952" y="443" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="987" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
+3.8
 </text>
 <text x="987" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.8%
++/-2.0%
 </text>
-<rect x="1027" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="1027" y="443" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="1062" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
+3.0
 </text>
 <text x="1062" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-0.5%
 </text>
-<rect x="1110" y="443" width="71" height="25" opacity="1" fill="#182131" stroke="none"/>
+<rect x="1110" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1145" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.3
+1.5
 </text>
 <text x="1145" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-11.8%
++/-4.2%
 </text>
-<rect x="1185" y="443" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
+<rect x="1185" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1220" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.7
+1.7
 </text>
 <text x="1220" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.8%
++/-4.5%
 </text>
-<rect x="1260" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<rect x="1260" y="443" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="1295" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.0
+2.3
 </text>
 <text x="1295" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.6%
++/-1.0%
 </text>
-<rect x="1335" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="1335" y="443" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
 <text x="1370" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
+3.4
 </text>
 <text x="1370" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.6%
++/-2.3%
 </text>
 <text x="28" y="484" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="472" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<rect x="186" y="472" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
 <text x="221" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.4
+6.5
 </text>
 <text x="221" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-11.1%
++/-44.6%
 </text>
-<rect x="261" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<rect x="261" y="472" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
 <text x="296" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.1
+6.4
 </text>
 <text x="296" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-20.7%
++/-42.4%
 </text>
-<rect x="336" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="336" y="472" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
 <text x="371" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+6.4
 </text>
 <text x="371" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.3%
++/-27.7%
 </text>
-<rect x="411" y="472" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="411" y="472" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="446" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
-</text>
-<text x="446" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-19.8%
-</text>
-<rect x="494" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="529" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
-</text>
-<text x="529" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.6%
-</text>
-<rect x="569" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="604" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
-</text>
-<text x="604" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-53.7%
-</text>
-<rect x="644" y="472" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
-<text x="679" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.2
-</text>
-<text x="679" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-16.4%
-</text>
-<rect x="719" y="472" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
-<text x="754" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.1
-</text>
-<text x="754" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-21.8%
-</text>
-<rect x="802" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="837" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
-</text>
-<text x="837" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.2%
-</text>
-<rect x="877" y="472" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
-<text x="912" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
-</text>
-<text x="912" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.2%
-</text>
-<rect x="952" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="987" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.4
 </text>
-<text x="987" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-30.9%
+<text x="446" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.3%
 </text>
-<rect x="1027" y="472" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<rect x="494" y="472" width="71" height="25" opacity="1" fill="#182131" stroke="none"/>
+<text x="529" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.6
+</text>
+<text x="529" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-25.2%
+</text>
+<rect x="569" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<text x="604" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.2
+</text>
+<text x="604" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-23.9%
+</text>
+<rect x="644" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<text x="679" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.9
+</text>
+<text x="679" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-71.0%
+</text>
+<rect x="719" y="472" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="754" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.7
+</text>
+<text x="754" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.4%
+</text>
+<rect x="802" y="472" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
+<text x="837" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.8
+</text>
+<text x="837" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-84.5%
+</text>
+<rect x="877" y="472" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
+<text x="912" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.0
+</text>
+<text x="912" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-48.1%
+</text>
+<rect x="952" y="472" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<text x="987" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.6
+</text>
+<text x="987" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-26.5%
+</text>
+<rect x="1027" y="472" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="1062" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.1
+7.5
 </text>
 <text x="1062" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-3.8%
 </text>
-<rect x="1110" y="472" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<rect x="1110" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="1145" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.2
+2.2
 </text>
 <text x="1145" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.9%
++/-13.1%
 </text>
-<rect x="1185" y="472" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="1185" y="472" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
 <text x="1220" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
+3.3
 </text>
 <text x="1220" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-11.2%
++/-7.6%
 </text>
-<rect x="1260" y="472" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
+<rect x="1260" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="1295" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.1
+4.9
 </text>
 <text x="1295" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.0%
++/-6.3%
 </text>
-<rect x="1335" y="472" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<rect x="1335" y="472" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
 <text x="1370" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.4
+6.2
 </text>
 <text x="1370" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.3%
++/-3.6%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,529 1416,529 "/>
 <text x="720" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes256 (256 B); median M items/s (+/- MAD); color scale 0-50; white outline = winner
+bytes256 (256 B); median M items/s (+/- MAD); color scale 0-60; white outline = winner
 </text>
 <text x="172" y="569" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 producer threads
@@ -1179,478 +1179,478 @@ implementation
 <text x="28" y="633" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="621" width="71" height="25" opacity="1" fill="#243550" stroke="none"/>
+<rect x="186" y="621" width="71" height="25" opacity="1" fill="#2B4466" stroke="none"/>
 <text x="221" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
+16.1
 </text>
 <text x="221" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
++/-0.1%
 </text>
-<rect x="261" y="621" width="71" height="25" opacity="1" fill="#314E75" stroke="none"/>
+<rect x="261" y="621" width="71" height="25" opacity="1" fill="#33537D" stroke="none"/>
 <rect x="261" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.2
+22.9
 </text>
 <text x="296" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
-</text>
-<rect x="336" y="621" width="71" height="25" opacity="1" fill="#365886" stroke="none"/>
-<rect x="336" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="371" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.2
-</text>
-<text x="371" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
-</text>
-<rect x="411" y="621" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
-<rect x="411" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="446" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.2
-</text>
-<text x="446" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.6%
 </text>
-<rect x="494" y="621" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="336" y="621" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
+<rect x="336" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="371" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+25.7
+</text>
+<text x="371" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.4%
+</text>
+<rect x="411" y="621" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="411" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="446" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+14.8
+</text>
+<text x="446" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.6%
+</text>
+<rect x="494" y="621" width="71" height="25" opacity="1" fill="#2B4365" stroke="none"/>
 <text x="529" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.8
+15.9
 </text>
 <text x="529" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.3%
 </text>
-<rect x="569" y="621" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
+<rect x="569" y="621" width="71" height="25" opacity="1" fill="#34547F" stroke="none"/>
 <rect x="569" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.0
+23.3
 </text>
 <text x="604" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.3%
 </text>
-<rect x="644" y="621" width="71" height="25" opacity="1" fill="#4878B6" stroke="none"/>
+<rect x="644" y="621" width="71" height="25" opacity="1" fill="#4D82C4" stroke="none"/>
 <rect x="644" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="679" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.3
+<text x="679" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+44.1
 </text>
-<text x="679" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
+<text x="679" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.5%
 </text>
-<rect x="719" y="621" width="71" height="25" opacity="1" fill="#4A7CBC" stroke="none"/>
+<rect x="719" y="621" width="71" height="25" opacity="1" fill="#3A6091" stroke="none"/>
 <rect x="719" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="754" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-34.8
+<text x="754" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+28.7
 </text>
-<text x="754" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.7%
+<text x="754" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.1%
 </text>
-<rect x="802" y="621" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
+<rect x="802" y="621" width="71" height="25" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="802" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="837" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.7
+15.8
 </text>
 <text x="837" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.6%
 </text>
-<rect x="877" y="621" width="71" height="25" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="877" y="621" width="71" height="25" opacity="1" fill="#33527D" stroke="none"/>
 <rect x="877" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.2
+22.7
 </text>
 <text x="912" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
-</text>
-<rect x="952" y="621" width="71" height="25" opacity="1" fill="#3B6092" stroke="none"/>
-<rect x="952" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.2
-</text>
-<text x="987" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.3%
-</text>
-<rect x="1027" y="621" width="71" height="25" opacity="1" fill="#5692DD" stroke="none"/>
-<rect x="1027" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1062" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-42.9
-</text>
-<text x="1062" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.8%
 </text>
-<rect x="1110" y="621" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
-<text x="1145" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.6
+<rect x="952" y="621" width="71" height="25" opacity="1" fill="#3F689E" stroke="none"/>
+<rect x="952" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="987" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+32.6
 </text>
-<text x="1145" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="987" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.3%
+</text>
+<rect x="1027" y="621" width="71" height="25" opacity="1" fill="#5998E7" stroke="none"/>
+<rect x="1027" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1062" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+54.3
+</text>
+<text x="1062" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-2.4%
 </text>
-<rect x="1185" y="621" width="71" height="25" opacity="1" fill="#243551" stroke="none"/>
+<rect x="1110" y="621" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="1145" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.7
+</text>
+<text x="1145" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="1185" y="621" width="71" height="25" opacity="1" fill="#293F5F" stroke="none"/>
+<rect x="1185" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.1
+13.9
 </text>
 <text x="1220" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.5%
++/-19.1%
 </text>
-<rect x="1260" y="621" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
+<rect x="1260" y="621" width="71" height="25" opacity="1" fill="#365784" stroke="none"/>
 <rect x="1260" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.7
+24.9
 </text>
 <text x="1295" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
++/-17.7%
 </text>
-<rect x="1335" y="621" width="71" height="25" opacity="1" fill="#4879B7" stroke="none"/>
+<rect x="1335" y="621" width="71" height="25" opacity="1" fill="#538ED7" stroke="none"/>
 <rect x="1335" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="1370" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.3
+<text x="1370" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+49.5
 </text>
-<text x="1370" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
+<text x="1370" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-5.2%
 </text>
 <text x="28" y="662" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="650" width="71" height="25" opacity="1" fill="#3C6396" stroke="none"/>
+<rect x="186" y="650" width="71" height="25" opacity="1" fill="#395C8B" stroke="none"/>
 <rect x="186" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.2
+27.2
 </text>
 <text x="221" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
++/-7.6%
 </text>
-<rect x="261" y="650" width="71" height="25" opacity="1" fill="#283E5D" stroke="none"/>
+<rect x="261" y="650" width="71" height="25" opacity="1" fill="#263A57" stroke="none"/>
 <text x="296" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.2
+11.5
 </text>
 <text x="296" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.9%
++/-0.4%
 </text>
-<rect x="336" y="650" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
+<rect x="336" y="650" width="71" height="25" opacity="1" fill="#243753" stroke="none"/>
 <text x="371" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.5
+10.3
 </text>
 <text x="371" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
++/-0.5%
 </text>
-<rect x="411" y="650" width="71" height="25" opacity="1" fill="#253956" stroke="none"/>
+<rect x="411" y="650" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
 <text x="446" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.3
+9.2
 </text>
 <text x="446" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.9%
 </text>
-<rect x="494" y="650" width="71" height="25" opacity="1" fill="#304C73" stroke="none"/>
+<rect x="494" y="650" width="71" height="25" opacity="1" fill="#2E496E" stroke="none"/>
 <rect x="494" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.6
+18.5
 </text>
 <text x="529" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
++/-2.1%
 </text>
-<rect x="569" y="650" width="71" height="25" opacity="1" fill="#294060" stroke="none"/>
+<rect x="569" y="650" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <text x="604" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.9
+14.5
 </text>
 <text x="604" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.9%
++/-7.8%
 </text>
-<rect x="644" y="650" width="71" height="25" opacity="1" fill="#273C5A" stroke="none"/>
+<rect x="644" y="650" width="71" height="25" opacity="1" fill="#243652" stroke="none"/>
 <text x="679" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.4
+10.0
 </text>
 <text x="679" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.7%
++/-1.3%
 </text>
-<rect x="719" y="650" width="71" height="25" opacity="1" fill="#243753" stroke="none"/>
+<rect x="719" y="650" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
 <text x="754" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.6
+9.1
 </text>
 <text x="754" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-1.4%
 </text>
-<rect x="802" y="650" width="71" height="25" opacity="1" fill="#263A58" stroke="none"/>
-<rect x="802" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="802" y="650" width="71" height="25" opacity="1" fill="#243651" stroke="none"/>
 <text x="837" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.8
 </text>
 <text x="837" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.9%
 </text>
-<rect x="877" y="650" width="71" height="25" opacity="1" fill="#253753" stroke="none"/>
+<rect x="877" y="650" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
 <text x="912" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.8
 </text>
 <text x="912" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.3%
++/-1.3%
 </text>
-<rect x="952" y="650" width="71" height="25" opacity="1" fill="#273C5B" stroke="none"/>
+<rect x="952" y="650" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
 <text x="987" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.7
+11.4
 </text>
 <text x="987" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-0.7%
 </text>
-<rect x="1027" y="650" width="71" height="25" opacity="1" fill="#243652" stroke="none"/>
+<rect x="1027" y="650" width="71" height="25" opacity="1" fill="#243651" stroke="none"/>
 <text x="1062" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.4
+9.9
 </text>
 <text x="1062" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.3%
++/-6.8%
 </text>
-<rect x="1110" y="650" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<rect x="1110" y="650" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
 <rect x="1110" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1145" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.2
+9.5
 </text>
 <text x="1145" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-1.2%
 </text>
-<rect x="1185" y="650" width="71" height="25" opacity="1" fill="#253854" stroke="none"/>
-<rect x="1185" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="1185" y="650" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
 <text x="1220" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.9
+8.5
 </text>
 <text x="1220" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
++/-0.9%
 </text>
-<rect x="1260" y="650" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<rect x="1260" y="650" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
 <text x="1295" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.1
+8.1
 </text>
 <text x="1295" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.1%
++/-1.5%
 </text>
-<rect x="1335" y="650" width="71" height="25" opacity="1" fill="#263A57" stroke="none"/>
+<rect x="1335" y="650" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
 <text x="1370" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.6
+8.8
 </text>
 <text x="1370" y="669" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-2.3%
 </text>
 <text x="28" y="691" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="679" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<rect x="186" y="679" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
 <text x="221" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.2
+4.7
 </text>
 <text x="221" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.2%
++/-4.1%
 </text>
-<rect x="261" y="679" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="261" y="679" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
 <text x="296" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.1
+3.9
 </text>
 <text x="296" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.3%
++/-8.5%
 </text>
-<rect x="336" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="336" y="679" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="371" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
+3.4
 </text>
 <text x="371" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.5%
++/-3.9%
 </text>
-<rect x="411" y="679" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
+<rect x="411" y="679" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
 <text x="446" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.4
+1.2
 </text>
 <text x="446" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-1.7%
 </text>
-<rect x="494" y="679" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="494" y="679" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="529" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.0
+3.1
 </text>
 <text x="529" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
++/-1.3%
 </text>
-<rect x="569" y="679" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="569" y="679" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
 <text x="604" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.0
 </text>
 <text x="604" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-4.6%
 </text>
-<rect x="644" y="679" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="644" y="679" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
 <text x="679" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
+3.6
 </text>
 <text x="679" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-1.9%
 </text>
-<rect x="719" y="679" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
+<rect x="719" y="679" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="754" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.1
+1.7
 </text>
 <text x="754" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.9%
++/-2.5%
 </text>
-<rect x="802" y="679" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="802" y="679" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
 <text x="837" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
+2.0
 </text>
 <text x="837" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.7%
++/-0.9%
 </text>
-<rect x="877" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="877" y="679" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="912" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.9
+2.6
 </text>
 <text x="912" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
++/-0.3%
 </text>
-<rect x="952" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="952" y="679" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
 <text x="987" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.9
+2.9
 </text>
 <text x="987" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.6%
++/-4.0%
 </text>
-<rect x="1027" y="679" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="1027" y="679" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
 <text x="1062" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
+2.3
 </text>
 <text x="1062" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-1.3%
 </text>
-<rect x="1110" y="679" width="71" height="25" opacity="1" fill="#192131" stroke="none"/>
+<rect x="1110" y="679" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
 <text x="1145" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.4
+1.3
 </text>
 <text x="1145" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-39.7%
++/-3.2%
 </text>
-<rect x="1185" y="679" width="71" height="25" opacity="1" fill="#192131" stroke="none"/>
+<rect x="1185" y="679" width="71" height="25" opacity="1" fill="#192234" stroke="none"/>
 <text x="1220" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.4
+1.0
 </text>
 <text x="1220" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.5%
++/-6.1%
 </text>
-<rect x="1260" y="679" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
+<rect x="1260" y="679" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="1295" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.6
+1.4
 </text>
 <text x="1295" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.9%
++/-0.3%
 </text>
-<rect x="1335" y="679" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<rect x="1335" y="679" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="1370" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.6
+1.9
 </text>
 <text x="1370" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.2%
++/-8.5%
 </text>
 <text x="28" y="720" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="708" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
+<rect x="186" y="708" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
 <text x="221" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.4
+5.9
 </text>
 <text x="221" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.4%
++/-17.1%
 </text>
 <rect x="261" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="296" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.8
+4.5
 </text>
 <text x="296" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.4%
++/-18.1%
 </text>
-<rect x="336" y="708" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<rect x="336" y="708" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="371" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
+1.5
 </text>
 <text x="371" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-25.4%
++/-49.6%
 </text>
-<rect x="411" y="708" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="411" y="708" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="446" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
+2.6
 </text>
 <text x="446" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.1%
++/-30.7%
 </text>
-<rect x="494" y="708" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<rect x="494" y="708" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="529" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.7
-</text>
-<text x="529" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.1%
-</text>
-<rect x="569" y="708" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
-<text x="604" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.6
-</text>
-<text x="604" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
-</text>
-<rect x="644" y="708" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
-<text x="679" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.1
 </text>
-<text x="679" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.1%
+<text x="529" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-13.2%
 </text>
-<rect x="719" y="708" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="569" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="604" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.4
+</text>
+<text x="604" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.6%
+</text>
+<rect x="644" y="708" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="679" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.3
+</text>
+<text x="679" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-8.4%
+</text>
+<rect x="719" y="708" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="754" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
+3.0
 </text>
 <text x="754" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-31.0%
++/-13.1%
 </text>
-<rect x="802" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="802" y="708" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="837" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
+4.2
 </text>
 <text x="837" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-24.9%
++/-9.4%
 </text>
 <rect x="877" y="708" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
 <text x="912" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.9
+4.6
 </text>
 <text x="912" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.7%
++/-9.4%
 </text>
-<rect x="952" y="708" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<rect x="952" y="708" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="987" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.0
+5.6
 </text>
 <text x="987" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.3%
++/-2.5%
 </text>
-<rect x="1027" y="708" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="1027" y="708" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="1062" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.1
+4.4
 </text>
 <text x="1062" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.9%
++/-8.8%
 </text>
 <rect x="1110" y="708" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="1145" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
+3.3
 </text>
 <text x="1145" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-16.8%
++/-5.2%
 </text>
 <rect x="1185" y="708" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="1220" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
+4.2
 </text>
 <text x="1220" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.8%
++/-7.0%
 </text>
 <rect x="1260" y="708" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="1295" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.6
+5.5
 </text>
 <text x="1295" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.0%
++/-5.6%
 </text>
-<rect x="1335" y="708" width="71" height="25" opacity="1" fill="#202E46" stroke="none"/>
+<rect x="1335" y="708" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="1370" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.3
+5.7
 </text>
 <text x="1370" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.7%
++/-8.0%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,765 1416,765 "/>
 <text x="720" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">

--- a/doc/charts/mpsc.svg
+++ b/doc/charts/mpsc.svg
@@ -4,7 +4,7 @@
 fanring MPSC comparison
 </text>
 <text x="512" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; blocking operations; 5 samples; nominal capacity 8192 items
+Linux VM on a 2018 Mac Mini, 6 physical cores / 12 threads, performance governor, turbo off; try operations; 5 samples; nominal capacity 8192 items
 </text>
 <text x="512" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 u64 (8 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner
@@ -30,165 +30,196 @@ producer threads
 <text x="28" y="138" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="128" width="200" height="21" opacity="1" fill="#5692DD" stroke="none"/>
+<rect x="186" y="128" width="200" height="21" opacity="1" fill="#5998E6" stroke="none"/>
 <rect x="186" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-68.6
+71.9
 </text>
 <text x="286" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.9%
++/-0.1%
 </text>
-<rect x="390" y="128" width="200" height="21" opacity="1" fill="#528AD1" stroke="none"/>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="#5693DF" stroke="none"/>
 <rect x="390" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-63.9
+69.4
 </text>
 <text x="490" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-8.2%
++/-0.8%
 </text>
-<rect x="594" y="128" width="200" height="21" opacity="1" fill="#2F4A70" stroke="none"/>
+<rect x="594" y="128" width="200" height="21" opacity="1" fill="#5794E0" stroke="none"/>
 <rect x="594" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.2
+<text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+69.7
 </text>
-<text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
+<text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.7%
 </text>
-<rect x="798" y="128" width="200" height="21" opacity="1" fill="#294061" stroke="none"/>
+<rect x="798" y="128" width="200" height="21" opacity="1" fill="#5692DE" stroke="none"/>
 <rect x="798" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.3
+<text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+68.8
 </text>
-<text x="898" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.1%
+<text x="898" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.6%
 </text>
 <text x="28" y="163" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="153" width="200" height="21" opacity="1" fill="#253753" stroke="none"/>
+<rect x="186" y="153" width="200" height="21" opacity="1" fill="#263956" stroke="none"/>
 <text x="286" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14.0
+15.0
 </text>
 <text x="286" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
++/-2.4%
 </text>
-<rect x="390" y="153" width="200" height="21" opacity="1" fill="#2B4466" stroke="none"/>
+<rect x="390" y="153" width="200" height="21" opacity="1" fill="#385B89" stroke="none"/>
 <text x="490" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.6
+35.3
 </text>
 <text x="490" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.6%
++/-19.6%
 </text>
-<rect x="594" y="153" width="200" height="21" opacity="1" fill="#2A4061" stroke="none"/>
+<rect x="594" y="153" width="200" height="21" opacity="1" fill="#2A4264" stroke="none"/>
 <text x="694" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.5
+20.5
 </text>
 <text x="694" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-0.9%
 </text>
-<rect x="798" y="153" width="200" height="21" opacity="1" fill="#243651" stroke="none"/>
+<rect x="798" y="153" width="200" height="21" opacity="1" fill="#233550" stroke="none"/>
 <text x="898" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.0
+12.7
 </text>
 <text x="898" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
++/-9.3%
 </text>
 <text x="28" y="188" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
+concurrent-queue 2.5.0
 </text>
-<rect x="186" y="178" width="200" height="21" opacity="1" fill="#2E496E" stroke="none"/>
+<rect x="186" y="178" width="200" height="21" opacity="1" fill="#2E486D" stroke="none"/>
 <text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.4
+24.0
 </text>
 <text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
++/-3.9%
 </text>
-<rect x="390" y="178" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
+<rect x="390" y="178" width="200" height="21" opacity="1" fill="#23344F" stroke="none"/>
 <text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.5
+12.2
 </text>
 <text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.9%
++/-6.4%
 </text>
-<rect x="594" y="178" width="200" height="21" opacity="1" fill="#1F2C43" stroke="none"/>
+<rect x="594" y="178" width="200" height="21" opacity="1" fill="#202E45" stroke="none"/>
 <text x="694" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.4
+8.4
 </text>
 <text x="694" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
++/-0.9%
 </text>
-<rect x="798" y="178" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
+<rect x="798" y="178" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="898" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.0
-</text>
-<text x="898" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="203" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
-<text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.6
-</text>
-<text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
-</text>
-<rect x="390" y="203" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.6
 </text>
-<text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
+<text x="898" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
 </text>
-<rect x="594" y="203" width="200" height="21" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+thingbuf 0.1.6
+</text>
+<rect x="186" y="203" width="200" height="21" opacity="1" fill="#2D476B" stroke="none"/>
+<text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+23.5
+</text>
+<text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.2%
+</text>
+<rect x="390" y="203" width="200" height="21" opacity="1" fill="#202F46" stroke="none"/>
+<text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.8
+</text>
+<text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.5%
+</text>
+<rect x="594" y="203" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="694" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.1
+7.7
 </text>
 <text x="694" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.1%
++/-0.8%
 </text>
-<rect x="798" y="203" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<rect x="798" y="203" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
 <text x="898" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.7
+7.1
 </text>
 <text x="898" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-12.0%
++/-1.4%
 </text>
 <text x="28" y="238" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
+flume 0.12.0
 </text>
-<rect x="186" y="228" width="200" height="21" opacity="1" fill="#1C283B" stroke="none"/>
+<rect x="186" y="228" width="200" height="21" opacity="1" fill="#1E2C41" stroke="none"/>
 <text x="286" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+6.9
 </text>
 <text x="286" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.5%
++/-1.6%
 </text>
-<rect x="390" y="228" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="390" y="228" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="490" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
+5.8
 </text>
 <text x="490" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.4%
++/-2.1%
 </text>
-<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="694" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
+4.1
 </text>
 <text x="694" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-15.9%
++/-1.2%
 </text>
-<rect x="798" y="228" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
+<rect x="798" y="228" width="200" height="21" opacity="1" fill="#192334" stroke="none"/>
 <text x="898" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.3
+1.6
 </text>
 <text x="898" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.6%
++/-1.6%
+</text>
+<text x="28" y="263" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="253" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="286" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.2
+</text>
+<text x="286" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.4%
+</text>
+<rect x="390" y="253" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="490" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.5
+</text>
+<text x="490" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-21.0%
+</text>
+<rect x="594" y="253" width="200" height="21" opacity="1" fill="#1A2335" stroke="none"/>
+<text x="694" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.1
+</text>
+<text x="694" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-23.4%
+</text>
+<rect x="798" y="253" width="200" height="21" opacity="1" fill="#1A2335" stroke="none"/>
+<text x="898" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.9
+</text>
+<text x="898" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-14.6%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,293 1000,293 "/>
 <text x="512" y="309" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes64 (64 B); median M items/s (+/- MAD); color scale 0-40; white outline = winner
+bytes64 (64 B); median M items/s (+/- MAD); color scale 0-60; white outline = winner
 </text>
 <text x="28" y="340" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
@@ -211,165 +242,196 @@ producer threads
 <text x="28" y="374" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="364" width="200" height="21" opacity="1" fill="#5693DE" stroke="none"/>
-<text x="286" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-34.5
+<rect x="186" y="364" width="200" height="21" opacity="1" fill="#4574AF" stroke="none"/>
+<text x="286" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+37.7
 </text>
-<text x="286" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.0%
+<text x="286" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
 </text>
-<rect x="390" y="364" width="200" height="21" opacity="1" fill="#426DA5" stroke="none"/>
+<rect x="390" y="364" width="200" height="21" opacity="1" fill="#4573AD" stroke="none"/>
+<rect x="390" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-23.2
+37.3
 </text>
 <text x="490" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-0.3%
 </text>
-<rect x="594" y="364" width="200" height="21" opacity="1" fill="#33527C" stroke="none"/>
+<rect x="594" y="364" width="200" height="21" opacity="1" fill="#4573AE" stroke="none"/>
 <rect x="594" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.0
+37.3
 </text>
 <text x="694" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.1%
 </text>
-<rect x="798" y="364" width="200" height="21" opacity="1" fill="#33527B" stroke="none"/>
+<rect x="798" y="364" width="200" height="21" opacity="1" fill="#375A88" stroke="none"/>
 <rect x="798" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14.9
+26.2
 </text>
 <text x="898" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-18.4%
 </text>
 <text x="28" y="399" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="389" width="200" height="21" opacity="1" fill="#5998E6" stroke="none"/>
-<rect x="186" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="186" y="389" width="200" height="21" opacity="1" fill="#4C80C2" stroke="none"/>
 <text x="286" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-36.0
+43.3
 </text>
 <text x="286" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.9%
 </text>
-<rect x="390" y="389" width="200" height="21" opacity="1" fill="#4E84C8" stroke="none"/>
-<rect x="390" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-30.1
+<rect x="390" y="389" width="200" height="21" opacity="1" fill="#426DA5" stroke="none"/>
+<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+34.8
 </text>
-<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.2%
+<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
 </text>
-<rect x="594" y="389" width="200" height="21" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="594" y="389" width="200" height="21" opacity="1" fill="#253854" stroke="none"/>
 <text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.4
+10.6
 </text>
 <text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.0%
-</text>
-<rect x="798" y="389" width="200" height="21" opacity="1" fill="#293F60" stroke="none"/>
-<text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.4
-</text>
-<text x="898" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.4%
-</text>
-<text x="28" y="424" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
-</text>
-<rect x="186" y="414" width="200" height="21" opacity="1" fill="#4675B1" stroke="none"/>
-<text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.5
-</text>
-<text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
-</text>
-<rect x="390" y="414" width="200" height="21" opacity="1" fill="#263956" stroke="none"/>
-<text x="490" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.6
-</text>
-<text x="490" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<rect x="594" y="414" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
-<text x="694" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
-</text>
-<text x="694" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
-</text>
-<rect x="798" y="414" width="200" height="21" opacity="1" fill="#253855" stroke="none"/>
-<text x="898" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.3
-</text>
-<text x="898" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<text x="28" y="449" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="439" width="200" height="21" opacity="1" fill="#22334D" stroke="none"/>
-<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.7
-</text>
-<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="390" y="439" width="200" height="21" opacity="1" fill="#22334C" stroke="none"/>
-<text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.6
-</text>
-<text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.0%
-</text>
-<rect x="594" y="439" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.4
-</text>
-<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.5%
 </text>
-<rect x="798" y="439" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<rect x="798" y="389" width="200" height="21" opacity="1" fill="#243550" stroke="none"/>
+<text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.6
+</text>
+<text x="898" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.3%
+</text>
+<text x="28" y="424" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+concurrent-queue 2.5.0
+</text>
+<rect x="186" y="414" width="200" height="21" opacity="1" fill="#5D9FF1" stroke="none"/>
+<rect x="186" y="414" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+57.3
+</text>
+<text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.8%
+</text>
+<rect x="390" y="414" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<text x="490" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.9
+</text>
+<text x="490" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="594" y="414" width="200" height="21" opacity="1" fill="#22334D" stroke="none"/>
+<text x="694" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.6
+</text>
+<text x="694" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="798" y="414" width="200" height="21" opacity="1" fill="#21314A" stroke="none"/>
+<text x="898" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.9
+</text>
+<text x="898" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.3%
+</text>
+<text x="28" y="449" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+thingbuf 0.1.6
+</text>
+<rect x="186" y="439" width="200" height="21" opacity="1" fill="#375987" stroke="none"/>
+<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+25.8
+</text>
+<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
+</text>
+<rect x="390" y="439" width="200" height="21" opacity="1" fill="#21314A" stroke="none"/>
+<text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.8
+</text>
+<text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.3%
+</text>
+<rect x="594" y="439" width="200" height="21" opacity="1" fill="#22324B" stroke="none"/>
+<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.0
+</text>
+<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="798" y="439" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
 <text x="898" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.3
+7.1
 </text>
 <text x="898" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-26.2%
++/-4.0%
 </text>
 <text x="28" y="474" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
+flume 0.12.0
 </text>
-<rect x="186" y="464" width="200" height="21" opacity="1" fill="#23344E" stroke="none"/>
+<rect x="186" y="464" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
 <text x="286" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.0
+5.3
 </text>
 <text x="286" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-5.3%
 </text>
-<rect x="390" y="464" width="200" height="21" opacity="1" fill="#213149" stroke="none"/>
+<rect x="390" y="464" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="490" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.0
+4.1
 </text>
 <text x="490" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-13.8%
++/-1.3%
 </text>
-<rect x="594" y="464" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="594" y="464" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="694" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.0
+2.8
 </text>
 <text x="694" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-11.1%
++/-1.4%
 </text>
-<rect x="798" y="464" width="200" height="21" opacity="1" fill="#1B2638" stroke="none"/>
+<rect x="798" y="464" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="898" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 1.7
 </text>
 <text x="898" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.4%
++/-5.5%
+</text>
+<text x="28" y="499" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="489" width="200" height="21" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="286" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.4
+</text>
+<text x="286" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-58.6%
+</text>
+<rect x="390" y="489" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<text x="490" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.5
+</text>
+<text x="490" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-29.6%
+</text>
+<rect x="594" y="489" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<text x="694" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.5
+</text>
+<text x="694" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-29.5%
+</text>
+<rect x="798" y="489" width="200" height="21" opacity="1" fill="#1A2437" stroke="none"/>
+<text x="898" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.9
+</text>
+<text x="898" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-9.6%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,529 1000,529 "/>
 <text x="512" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes256 (256 B); median M items/s (+/- MAD); color scale 0-25; white outline = winner
+bytes256 (256 B); median M items/s (+/- MAD); color scale 0-40; white outline = winner
 </text>
 <text x="28" y="576" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
@@ -392,161 +454,192 @@ producer threads
 <text x="28" y="610" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="600" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
-<rect x="186" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="286" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-20.9
+<rect x="186" y="600" width="200" height="21" opacity="1" fill="#426EA7" stroke="none"/>
+<text x="286" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+23.6
 </text>
-<text x="286" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.2%
+<text x="286" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
 </text>
-<rect x="390" y="600" width="200" height="21" opacity="1" fill="#4675B1" stroke="none"/>
+<rect x="390" y="600" width="200" height="21" opacity="1" fill="#426EA7" stroke="none"/>
+<rect x="390" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.9
+23.5
 </text>
 <text x="490" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
++/-2.2%
 </text>
-<rect x="594" y="600" width="200" height="21" opacity="1" fill="#395C8C" stroke="none"/>
+<rect x="594" y="600" width="200" height="21" opacity="1" fill="#416CA4" stroke="none"/>
 <rect x="594" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.4
+23.0
 </text>
 <text x="694" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-2.7%
 </text>
-<rect x="798" y="600" width="200" height="21" opacity="1" fill="#283D5C" stroke="none"/>
+<rect x="798" y="600" width="200" height="21" opacity="1" fill="#40699F" stroke="none"/>
+<rect x="798" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.4
+22.0
 </text>
 <text x="898" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.5%
++/-7.1%
 </text>
 <text x="28" y="635" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="625" width="200" height="21" opacity="1" fill="#3D6599" stroke="none"/>
-<text x="286" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.0
+<rect x="186" y="625" width="200" height="21" opacity="1" fill="#497BBA" stroke="none"/>
+<text x="286" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+27.3
 </text>
-<text x="286" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.1%
+<text x="286" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.2%
 </text>
-<rect x="390" y="625" width="200" height="21" opacity="1" fill="#4676B2" stroke="none"/>
-<rect x="390" y="625" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="390" y="625" width="200" height="21" opacity="1" fill="#33527C" stroke="none"/>
 <text x="490" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.1
+15.1
 </text>
 <text x="490" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.0%
++/-4.5%
 </text>
-<rect x="594" y="625" width="200" height="21" opacity="1" fill="#355580" stroke="none"/>
+<rect x="594" y="625" width="200" height="21" opacity="1" fill="#293F60" stroke="none"/>
 <text x="694" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.0
+9.5
 </text>
 <text x="694" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-0.6%
 </text>
-<rect x="798" y="625" width="200" height="21" opacity="1" fill="#34547F" stroke="none"/>
-<rect x="798" y="625" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="798" y="625" width="200" height="21" opacity="1" fill="#293F5F" stroke="none"/>
 <text x="898" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
+9.4
 </text>
 <text x="898" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.2%
++/-1.6%
 </text>
 <text x="28" y="660" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
+concurrent-queue 2.5.0
 </text>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="#4E84C9" stroke="none"/>
+<rect x="186" y="650" width="200" height="21" opacity="1" fill="#548ED7" stroke="none"/>
+<rect x="186" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-18.9
+33.1
 </text>
 <text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.8%
++/-0.4%
 </text>
-<rect x="390" y="650" width="200" height="21" opacity="1" fill="#2A4263" stroke="none"/>
+<rect x="390" y="650" width="200" height="21" opacity="1" fill="#2B4264" stroke="none"/>
 <text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.3
+10.3
 </text>
 <text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
++/-0.6%
 </text>
-<rect x="594" y="650" width="200" height="21" opacity="1" fill="#2D486C" stroke="none"/>
+<rect x="594" y="650" width="200" height="21" opacity="1" fill="#273C5B" stroke="none"/>
 <text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.4
+8.5
 </text>
 <text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
++/-0.6%
 </text>
-<rect x="798" y="650" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="798" y="650" width="200" height="21" opacity="1" fill="#263957" stroke="none"/>
 <text x="898" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.1
+7.6
 </text>
 <text x="898" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-58.0%
++/-0.3%
 </text>
 <text x="28" y="685" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
+thingbuf 0.1.6
 </text>
-<rect x="186" y="675" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
+<rect x="186" y="675" width="200" height="21" opacity="1" fill="#3A6091" stroke="none"/>
 <text x="286" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
+19.1
 </text>
 <text x="286" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-0.5%
 </text>
 <rect x="390" y="675" width="200" height="21" opacity="1" fill="#23344F" stroke="none"/>
 <text x="490" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.8
-</text>
-<text x="490" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.3%
-</text>
-<rect x="594" y="675" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="694" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.5
-</text>
-<text x="694" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="798" y="675" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
-<text x="898" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.2
-</text>
-<text x="898" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.2%
-</text>
-<text x="28" y="710" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="700" width="200" height="21" opacity="1" fill="#2A4061" stroke="none"/>
-<text x="286" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.1
 </text>
-<text x="286" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.7%
+<text x="490" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.4%
 </text>
-<rect x="390" y="700" width="200" height="21" opacity="1" fill="#253855" stroke="none"/>
+<rect x="594" y="675" width="200" height="21" opacity="1" fill="#263A57" stroke="none"/>
+<text x="694" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.8
+</text>
+<text x="694" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="798" y="675" width="200" height="21" opacity="1" fill="#22324B" stroke="none"/>
+<text x="898" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.3
+</text>
+<text x="898" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-11.6%
+</text>
+<text x="28" y="710" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="700" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<text x="286" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.3
+</text>
+<text x="286" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="390" y="700" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="490" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+2.9
 </text>
 <text x="490" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.9%
++/-2.4%
 </text>
-<rect x="594" y="700" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<rect x="594" y="700" width="200" height="21" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="694" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.7
+2.1
 </text>
 <text x="694" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
++/-0.7%
 </text>
-<rect x="798" y="700" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
+<rect x="798" y="700" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
 <text x="898" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
+0.7
 </text>
 <text x="898" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.4%
++/-5.7%
+</text>
+<text x="28" y="735" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="725" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="286" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.3
+</text>
+<text x="286" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-74.4%
+</text>
+<rect x="390" y="725" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="490" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.8
+</text>
+<text x="490" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.5%
+</text>
+<rect x="594" y="725" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="694" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.3
+</text>
+<text x="694" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.3%
+</text>
+<rect x="798" y="725" width="200" height="21" opacity="1" fill="#1C283D" stroke="none"/>
+<text x="898" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.5
+</text>
+<text x="898" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-24.3%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,765 1000,765 "/>
 <text x="512" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">

--- a/doc/charts/mpsc.svg
+++ b/doc/charts/mpsc.svg
@@ -4,7 +4,7 @@
 fanring MPSC comparison
 </text>
 <text x="512" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; try operations; 5 samples; nominal capacity 8192 items
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; blocking operations; 5 samples; nominal capacity 8192 items
 </text>
 <text x="512" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 u64 (8 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner
@@ -30,196 +30,165 @@ producer threads
 <text x="28" y="138" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="128" width="200" height="21" opacity="1" fill="#5896E3" stroke="none"/>
+<rect x="186" y="128" width="200" height="21" opacity="1" fill="#5692DD" stroke="none"/>
 <rect x="186" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-71.0
+68.6
 </text>
 <text x="286" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.3%
++/-0.9%
 </text>
-<rect x="390" y="128" width="200" height="21" opacity="1" fill="#5693DE" stroke="none"/>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="#528AD1" stroke="none"/>
 <rect x="390" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-68.9
+63.9
 </text>
 <text x="490" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.9%
++/-8.2%
 </text>
-<rect x="594" y="128" width="200" height="21" opacity="1" fill="#5692DE" stroke="none"/>
+<rect x="594" y="128" width="200" height="21" opacity="1" fill="#2F4A70" stroke="none"/>
 <rect x="594" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-68.8
+<text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+25.2
 </text>
-<text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.2%
+<text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.4%
 </text>
-<rect x="798" y="128" width="200" height="21" opacity="1" fill="#365784" stroke="none"/>
+<rect x="798" y="128" width="200" height="21" opacity="1" fill="#294061" stroke="none"/>
 <rect x="798" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.2
+19.3
 </text>
 <text x="898" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.2%
++/-2.1%
 </text>
 <text x="28" y="163" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="153" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<rect x="186" y="153" width="200" height="21" opacity="1" fill="#253753" stroke="none"/>
 <text x="286" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.7
+14.0
 </text>
 <text x="286" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.3%
++/-2.0%
 </text>
-<rect x="390" y="153" width="200" height="21" opacity="1" fill="#2C4569" stroke="none"/>
+<rect x="390" y="153" width="200" height="21" opacity="1" fill="#2B4466" stroke="none"/>
 <text x="490" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.5
+21.6
 </text>
 <text x="490" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.6%
++/-4.6%
 </text>
-<rect x="594" y="153" width="200" height="21" opacity="1" fill="#2A4161" stroke="none"/>
+<rect x="594" y="153" width="200" height="21" opacity="1" fill="#2A4061" stroke="none"/>
 <text x="694" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.6
+19.5
 </text>
 <text x="694" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-0.7%
 </text>
-<rect x="798" y="153" width="200" height="21" opacity="1" fill="#22334D" stroke="none"/>
+<rect x="798" y="153" width="200" height="21" opacity="1" fill="#243651" stroke="none"/>
 <text x="898" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.7
-</text>
-<text x="898" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.4%
-</text>
-<text x="28" y="188" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-concurrent-queue 2.5.0
-</text>
-<rect x="186" y="178" width="200" height="21" opacity="1" fill="#2D476C" stroke="none"/>
-<text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-23.6
-</text>
-<text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.8%
-</text>
-<rect x="390" y="178" width="200" height="21" opacity="1" fill="#243651" stroke="none"/>
-<text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 13.0
 </text>
-<text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
-</text>
-<rect x="594" y="178" width="200" height="21" opacity="1" fill="#202E45" stroke="none"/>
-<text x="694" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.5
-</text>
-<text x="694" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
-</text>
-<rect x="798" y="178" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
-<text x="898" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
-</text>
-<text x="898" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
-</text>
-<rect x="186" y="203" width="200" height="21" opacity="1" fill="#2D486C" stroke="none"/>
-<text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-23.9
-</text>
-<text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
-</text>
-<rect x="390" y="203" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
-<text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.0
-</text>
-<text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.2%
-</text>
-<rect x="594" y="203" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="694" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
-</text>
-<text x="694" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="798" y="203" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
-<text x="898" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.0
-</text>
-<text x="898" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
-</text>
-<text x="28" y="238" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="228" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="286" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.7
-</text>
-<text x="286" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
-</text>
-<rect x="390" y="228" width="200" height="21" opacity="1" fill="#1E2B40" stroke="none"/>
-<text x="490" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.5
-</text>
-<text x="490" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="898" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.1%
 </text>
-<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="694" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.4
+<text x="28" y="188" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+thingbuf 0.1.6
 </text>
-<text x="694" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<rect x="186" y="178" width="200" height="21" opacity="1" fill="#2E496E" stroke="none"/>
+<text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+24.4
+</text>
+<text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.5%
+</text>
+<rect x="390" y="178" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
+<text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.5
+</text>
+<text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.9%
+</text>
+<rect x="594" y="178" width="200" height="21" opacity="1" fill="#1F2C43" stroke="none"/>
+<text x="694" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.4
+</text>
+<text x="694" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.6%
+</text>
+<rect x="798" y="178" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="898" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.0
+</text>
+<text x="898" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="203" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.6
+</text>
+<text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="390" y="203" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.6
+</text>
+<text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.3%
 </text>
-<rect x="798" y="228" width="200" height="21" opacity="1" fill="#1A2334" stroke="none"/>
-<text x="898" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
+<rect x="594" y="203" width="200" height="21" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="694" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.1
 </text>
-<text x="898" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.7%
+<text x="694" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.1%
 </text>
-<text x="28" y="263" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+<rect x="798" y="203" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<text x="898" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.7
+</text>
+<text x="898" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-12.0%
+</text>
+<text x="28" y="238" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="253" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="286" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.4
+<rect x="186" y="228" width="200" height="21" opacity="1" fill="#1C283B" stroke="none"/>
+<text x="286" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.5
 </text>
-<text x="286" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.3%
+<text x="286" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.5%
 </text>
-<rect x="390" y="253" width="200" height="21" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="490" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
+<rect x="390" y="228" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="490" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.4
 </text>
-<text x="490" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.8%
+<text x="490" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.4%
 </text>
-<rect x="594" y="253" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
-<text x="694" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
+<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="694" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.2
 </text>
-<text x="694" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.9%
+<text x="694" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-15.9%
 </text>
-<rect x="798" y="253" width="200" height="21" opacity="1" fill="#1A2334" stroke="none"/>
-<text x="898" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
+<rect x="798" y="228" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
+<text x="898" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.3
 </text>
-<text x="898" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-16.7%
+<text x="898" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.6%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,293 1000,293 "/>
 <text x="512" y="309" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes64 (64 B); median M items/s (+/- MAD); color scale 0-60; white outline = winner
+bytes64 (64 B); median M items/s (+/- MAD); color scale 0-40; white outline = winner
 </text>
 <text x="28" y="340" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
@@ -242,196 +211,165 @@ producer threads
 <text x="28" y="374" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="364" width="200" height="21" opacity="1" fill="#4675B0" stroke="none"/>
-<text x="286" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-38.1
+<rect x="186" y="364" width="200" height="21" opacity="1" fill="#5693DE" stroke="none"/>
+<text x="286" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+34.5
 </text>
-<text x="286" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
+<text x="286" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.0%
 </text>
-<rect x="390" y="364" width="200" height="21" opacity="1" fill="#3B6293" stroke="none"/>
+<rect x="390" y="364" width="200" height="21" opacity="1" fill="#426DA5" stroke="none"/>
 <text x="490" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.6
+23.2
 </text>
 <text x="490" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.6%
 </text>
-<rect x="594" y="364" width="200" height="21" opacity="1" fill="#3B6192" stroke="none"/>
+<rect x="594" y="364" width="200" height="21" opacity="1" fill="#33527C" stroke="none"/>
 <rect x="594" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.1
+15.0
 </text>
 <text x="694" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.0%
 </text>
-<rect x="798" y="364" width="200" height="21" opacity="1" fill="#325078" stroke="none"/>
+<rect x="798" y="364" width="200" height="21" opacity="1" fill="#33527B" stroke="none"/>
 <rect x="798" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.4
+14.9
 </text>
 <text x="898" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-1.2%
 </text>
 <text x="28" y="399" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="389" width="200" height="21" opacity="1" fill="#4A7CBC" stroke="none"/>
+<rect x="186" y="389" width="200" height="21" opacity="1" fill="#5998E6" stroke="none"/>
+<rect x="186" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-41.5
+36.0
 </text>
 <text x="286" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.7%
++/-0.9%
 </text>
-<rect x="390" y="389" width="200" height="21" opacity="1" fill="#416CA3" stroke="none"/>
+<rect x="390" y="389" width="200" height="21" opacity="1" fill="#4E84C8" stroke="none"/>
 <rect x="390" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.2
+<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+30.1
 </text>
-<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
+<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.2%
 </text>
-<rect x="594" y="389" width="200" height="21" opacity="1" fill="#243752" stroke="none"/>
+<rect x="594" y="389" width="200" height="21" opacity="1" fill="#2B4365" stroke="none"/>
 <text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.2
+10.4
 </text>
 <text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-3.0%
 </text>
-<rect x="798" y="389" width="200" height="21" opacity="1" fill="#23354F" stroke="none"/>
+<rect x="798" y="389" width="200" height="21" opacity="1" fill="#293F60" stroke="none"/>
 <text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.4
 </text>
 <text x="898" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.9%
++/-4.4%
 </text>
 <text x="28" y="424" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-concurrent-queue 2.5.0
-</text>
-<rect x="186" y="414" width="200" height="21" opacity="1" fill="#5FA4F8" stroke="none"/>
-<rect x="186" y="414" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-59.5
-</text>
-<text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.3%
-</text>
-<rect x="390" y="414" width="200" height="21" opacity="1" fill="#283D5D" stroke="none"/>
-<text x="490" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.3
-</text>
-<text x="490" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.1%
-</text>
-<rect x="594" y="414" width="200" height="21" opacity="1" fill="#22334C" stroke="none"/>
-<text x="694" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.4
-</text>
-<text x="694" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
-</text>
-<rect x="798" y="414" width="200" height="21" opacity="1" fill="#22324B" stroke="none"/>
-<text x="898" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.9
-</text>
-<text x="898" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
-</text>
-<text x="28" y="449" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 thingbuf 0.1.6
 </text>
-<rect x="186" y="439" width="200" height="21" opacity="1" fill="#365886" stroke="none"/>
-<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.4
+<rect x="186" y="414" width="200" height="21" opacity="1" fill="#4675B1" stroke="none"/>
+<text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+25.5
 </text>
-<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
+<text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
 </text>
-<rect x="390" y="439" width="200" height="21" opacity="1" fill="#22324B" stroke="none"/>
-<text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.1
+<rect x="390" y="414" width="200" height="21" opacity="1" fill="#263956" stroke="none"/>
+<text x="490" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.6
 </text>
-<text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.5%
-</text>
-<rect x="594" y="439" width="200" height="21" opacity="1" fill="#22324B" stroke="none"/>
-<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
-</text>
-<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
-</text>
-<rect x="798" y="439" width="200" height="21" opacity="1" fill="#203048" stroke="none"/>
-<text x="898" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.0
-</text>
-<text x="898" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<text x="28" y="474" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="464" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
-<text x="286" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.9
-</text>
-<text x="286" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="490" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.6%
 </text>
-<rect x="390" y="464" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
-<text x="490" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.2
+<rect x="594" y="414" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<text x="694" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.0
 </text>
-<text x="490" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="694" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.7%
 </text>
-<rect x="594" y="464" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="798" y="414" width="200" height="21" opacity="1" fill="#253855" stroke="none"/>
+<text x="898" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.3
+</text>
+<text x="898" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<text x="28" y="449" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="439" width="200" height="21" opacity="1" fill="#22334D" stroke="none"/>
+<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.7
+</text>
+<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="390" y="439" width="200" height="21" opacity="1" fill="#22334C" stroke="none"/>
+<text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.6
+</text>
+<text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.0%
+</text>
+<rect x="594" y="439" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.4
+</text>
+<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.5%
+</text>
+<rect x="798" y="439" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<text x="898" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.3
+</text>
+<text x="898" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-26.2%
+</text>
+<text x="28" y="474" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="464" width="200" height="21" opacity="1" fill="#23344E" stroke="none"/>
+<text x="286" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.0
+</text>
+<text x="286" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.9%
+</text>
+<rect x="390" y="464" width="200" height="21" opacity="1" fill="#213149" stroke="none"/>
+<text x="490" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.0
+</text>
+<text x="490" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-13.8%
+</text>
+<rect x="594" y="464" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="694" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
+3.0
 </text>
 <text x="694" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-11.1%
 </text>
-<rect x="798" y="464" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="798" y="464" width="200" height="21" opacity="1" fill="#1B2638" stroke="none"/>
 <text x="898" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 1.7
 </text>
 <text x="898" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<text x="28" y="499" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="489" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
-<text x="286" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
-</text>
-<text x="286" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
-</text>
-<rect x="390" y="489" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
-<text x="490" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.9
-</text>
-<text x="490" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-71.6%
-</text>
-<rect x="594" y="489" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="694" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.6
-</text>
-<text x="694" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-19.0%
-</text>
-<rect x="798" y="489" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
-<text x="898" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.1
-</text>
-<text x="898" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
++/-8.4%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,529 1000,529 "/>
 <text x="512" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes256 (256 B); median M items/s (+/- MAD); color scale 0-40; white outline = winner
+bytes256 (256 B); median M items/s (+/- MAD); color scale 0-25; white outline = winner
 </text>
 <text x="28" y="576" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
@@ -454,192 +392,161 @@ producer threads
 <text x="28" y="610" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="600" width="200" height="21" opacity="1" fill="#40699F" stroke="none"/>
-<text x="286" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.0
+<rect x="186" y="600" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="186" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="286" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+20.9
 </text>
-<text x="286" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
+<text x="286" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.2%
 </text>
-<rect x="390" y="600" width="200" height="21" opacity="1" fill="#3E679B" stroke="none"/>
-<rect x="390" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="390" y="600" width="200" height="21" opacity="1" fill="#4675B1" stroke="none"/>
 <text x="490" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.2
+15.9
 </text>
 <text x="490" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-2.8%
 </text>
-<rect x="594" y="600" width="200" height="21" opacity="1" fill="#3D6599" stroke="none"/>
+<rect x="594" y="600" width="200" height="21" opacity="1" fill="#395C8C" stroke="none"/>
 <rect x="594" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-20.8
+11.4
 </text>
 <text x="694" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-0.7%
 </text>
-<rect x="798" y="600" width="200" height="21" opacity="1" fill="#3F699F" stroke="none"/>
-<rect x="798" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="798" y="600" width="200" height="21" opacity="1" fill="#283D5C" stroke="none"/>
 <text x="898" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.9
+5.4
 </text>
 <text x="898" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-7.5%
 </text>
 <text x="28" y="635" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="625" width="200" height="21" opacity="1" fill="#4A7DBD" stroke="none"/>
-<text x="286" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-27.9
+<rect x="186" y="625" width="200" height="21" opacity="1" fill="#3D6599" stroke="none"/>
+<text x="286" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+13.0
 </text>
-<text x="286" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.5%
+<text x="286" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.1%
 </text>
-<rect x="390" y="625" width="200" height="21" opacity="1" fill="#375A88" stroke="none"/>
+<rect x="390" y="625" width="200" height="21" opacity="1" fill="#4676B2" stroke="none"/>
+<rect x="390" y="625" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.4
+16.1
 </text>
 <text x="490" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-5.0%
 </text>
-<rect x="594" y="625" width="200" height="21" opacity="1" fill="#293F5F" stroke="none"/>
+<rect x="594" y="625" width="200" height="21" opacity="1" fill="#355580" stroke="none"/>
 <text x="694" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.3
+10.0
 </text>
 <text x="694" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-0.4%
 </text>
-<rect x="798" y="625" width="200" height="21" opacity="1" fill="#293F60" stroke="none"/>
+<rect x="798" y="625" width="200" height="21" opacity="1" fill="#34547F" stroke="none"/>
+<rect x="798" y="625" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.5
+9.7
 </text>
 <text x="898" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
++/-3.2%
 </text>
 <text x="28" y="660" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-concurrent-queue 2.5.0
-</text>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="#538DD6" stroke="none"/>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-32.8
-</text>
-<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-2.7%
-</text>
-<rect x="390" y="650" width="200" height="21" opacity="1" fill="#2B4366" stroke="none"/>
-<text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.6
-</text>
-<text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.2%
-</text>
-<rect x="594" y="650" width="200" height="21" opacity="1" fill="#283D5C" stroke="none"/>
-<text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.7
-</text>
-<text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="798" y="650" width="200" height="21" opacity="1" fill="#263A57" stroke="none"/>
-<text x="898" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.7
-</text>
-<text x="898" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
-</text>
-<text x="28" y="685" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 thingbuf 0.1.6
 </text>
-<rect x="186" y="675" width="200" height="21" opacity="1" fill="#3B6091" stroke="none"/>
-<text x="286" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.2
+<rect x="186" y="650" width="200" height="21" opacity="1" fill="#4E84C9" stroke="none"/>
+<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+18.9
 </text>
-<text x="286" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
+<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.8%
 </text>
-<rect x="390" y="675" width="200" height="21" opacity="1" fill="#23354F" stroke="none"/>
-<text x="490" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.2
+<rect x="390" y="650" width="200" height="21" opacity="1" fill="#2A4263" stroke="none"/>
+<text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.3
 </text>
-<text x="490" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.5%
+<text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.5%
 </text>
-<rect x="594" y="675" width="200" height="21" opacity="1" fill="#273B59" stroke="none"/>
-<text x="694" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.1
+<rect x="594" y="650" width="200" height="21" opacity="1" fill="#2D486C" stroke="none"/>
+<text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.4
 </text>
-<text x="694" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
-</text>
-<rect x="798" y="675" width="200" height="21" opacity="1" fill="#213149" stroke="none"/>
-<text x="898" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.0
-</text>
-<text x="898" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.4%
-</text>
-<text x="28" y="710" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="700" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
-<text x="286" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.0
-</text>
-<text x="286" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
-</text>
-<rect x="390" y="700" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
-<text x="490" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
-</text>
-<text x="490" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.4%
 </text>
-<rect x="594" y="700" width="200" height="21" opacity="1" fill="#1C273A" stroke="none"/>
-<text x="694" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
-</text>
-<text x="694" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<rect x="798" y="700" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="898" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.2
-</text>
-<text x="898" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.6%
-</text>
-<text x="28" y="735" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="725" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
-<text x="286" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.7
-</text>
-<text x="286" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-58.2%
-</text>
-<rect x="390" y="725" width="200" height="21" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="490" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.0
-</text>
-<text x="490" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-51.8%
-</text>
-<rect x="594" y="725" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="694" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="798" y="650" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="898" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 1.1
 </text>
-<text x="694" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-69.3%
+<text x="898" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-58.0%
 </text>
-<rect x="798" y="725" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="898" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.4
+<text x="28" y="685" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
 </text>
-<text x="898" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.7%
+<rect x="186" y="675" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
+<text x="286" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.3
+</text>
+<text x="286" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="390" y="675" width="200" height="21" opacity="1" fill="#23344F" stroke="none"/>
+<text x="490" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.8
+</text>
+<text x="490" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.3%
+</text>
+<rect x="594" y="675" width="200" height="21" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="694" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.5
+</text>
+<text x="694" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="798" y="675" width="200" height="21" opacity="1" fill="#192132" stroke="none"/>
+<text x="898" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.2
+</text>
+<text x="898" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.2%
+</text>
+<text x="28" y="710" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="700" width="200" height="21" opacity="1" fill="#2A4061" stroke="none"/>
+<text x="286" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.1
+</text>
+<text x="286" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.7%
+</text>
+<rect x="390" y="700" width="200" height="21" opacity="1" fill="#253855" stroke="none"/>
+<text x="490" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.5
+</text>
+<text x="490" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.9%
+</text>
+<rect x="594" y="700" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<text x="694" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.7
+</text>
+<text x="694" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.0%
+</text>
+<rect x="798" y="700" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="898" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.7
+</text>
+<text x="898" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-10.4%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,765 1000,765 "/>
 <text x="512" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">

--- a/doc/charts/summary.svg
+++ b/doc/charts/summary.svg
@@ -9,36 +9,36 @@ Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off
 <text x="22" y="190" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 190)">
 million items/s
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,262 830,262 "/>
-<text x="62" y="262" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,260 830,260 "/>
+<text x="62" y="260" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 20
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,205 830,205 "/>
-<text x="62" y="205" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,202 830,202 "/>
+<text x="62" y="202" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 40
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,149 830,149 "/>
-<text x="62" y="149" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,144 830,144 "/>
+<text x="62" y="144" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 60
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,92 830,92 "/>
-<text x="62" y="92" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,86 830,86 "/>
+<text x="62" y="86" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 80
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,318 830,318 "/>
-<rect x="123" y="124" width="44" height="194" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="169" y="263" width="44" height="55" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="215" y="294" width="44" height="24" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="261" y="297" width="44" height="21" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="123" y="115" width="44" height="203" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="169" y="262" width="44" height="56" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="215" y="293" width="44" height="25" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="261" y="296" width="44" height="22" opacity="1" fill="#A78BFA" stroke="none"/>
 <rect x="307" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="353" y="310" width="44" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="353" y="312" width="44" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="260" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPSC: 4 producers
 </text>
 <rect x="549" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="595" y="247" width="44" height="71" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="641" y="305" width="44" height="13" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="687" y="300" width="44" height="18" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="595" y="242" width="44" height="76" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="641" y="304" width="44" height="14" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="687" y="295" width="44" height="23" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="640" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPMC: 4 producers / 4 consumers
 </text>

--- a/doc/charts/summary.svg
+++ b/doc/charts/summary.svg
@@ -4,41 +4,45 @@
 u64 channel throughput with capacity=8192 (higher is better)
 </text>
 <text x="425" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off
+Linux VM on a 2018 Mac Mini, 6 physical cores / 12 threads, performance governor, turbo off
 </text>
 <text x="22" y="190" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 190)">
 million items/s
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,260 830,260 "/>
-<text x="62" y="260" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,269 830,269 "/>
+<text x="62" y="269" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 20
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,202 830,202 "/>
-<text x="62" y="202" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,219 830,219 "/>
+<text x="62" y="219" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 40
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,144 830,144 "/>
-<text x="62" y="144" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,170 830,170 "/>
+<text x="62" y="170" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 60
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,86 830,86 "/>
-<text x="62" y="86" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,120 830,120 "/>
+<text x="62" y="120" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 80
 </text>
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,71 830,71 "/>
+<text x="62" y="71" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+100
+</text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,318 830,318 "/>
-<rect x="123" y="115" width="44" height="203" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="169" y="262" width="44" height="56" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="215" y="293" width="44" height="25" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="261" y="296" width="44" height="22" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="307" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="353" y="312" width="44" height="6" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="123" y="146" width="44" height="172" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="169" y="267" width="44" height="51" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="215" y="297" width="44" height="21" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="261" y="299" width="44" height="19" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="307" y="308" width="44" height="10" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="353" y="313" width="44" height="5" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="260" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPSC: 4 producers
 </text>
 <rect x="549" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="595" y="242" width="44" height="76" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="641" y="304" width="44" height="14" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="687" y="295" width="44" height="23" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="595" y="269" width="44" height="49" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="641" y="307" width="44" height="11" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="687" y="303" width="44" height="15" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="640" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPMC: 4 producers / 4 consumers
 </text>

--- a/src/bin/chart.rs
+++ b/src/bin/chart.rs
@@ -26,6 +26,7 @@ const BACKGROUND_COLOR: RGBColor = RGBColor(0, 0, 0);
 const GRID_COLOR: RGBColor = RGBColor(55, 65, 81);
 const TEXT_COLOR: RGBColor = RGBColor(229, 231, 235);
 const MUTED_TEXT_COLOR: RGBColor = RGBColor(156, 163, 175);
+const DEFAULT_CHART_MODE: &str = "try";
 
 type ChartResult<T> = Result<T, ChartError>;
 
@@ -152,7 +153,7 @@ fn run_detail() -> ChartResult<()> {
         return Err(ChartError::NoRows { path: input });
     }
 
-    let rows = select_run(rows, arg_value("--run"))?;
+    let rows = select_run_with_default_mode(rows, arg_value("--run"), Some(DEFAULT_CHART_MODE))?;
     prepare_output(&output)?;
     draw_chart(&rows, &output)?;
     println!("wrote {}", output.display());
@@ -171,8 +172,16 @@ fn run_summary() -> ChartResult<()> {
     let output = arg_value("--output")
         .map_or_else(|| PathBuf::from("doc/charts/summary.svg"), PathBuf::from);
 
-    let mpsc_rows = read_rows_for_run(&mpsc_input, arg_value("--mpsc-run"), Some("try"))?;
-    let mpmc_rows = read_rows_for_run(&mpmc_input, arg_value("--mpmc-run"), Some("try"))?;
+    let mpsc_rows = read_rows_for_run(
+        &mpsc_input,
+        arg_value("--mpsc-run"),
+        Some(DEFAULT_CHART_MODE),
+    )?;
+    let mpmc_rows = read_rows_for_run(
+        &mpmc_input,
+        arg_value("--mpmc-run"),
+        Some(DEFAULT_CHART_MODE),
+    )?;
     prepare_output(&output)?;
     draw_summary_chart(&mpsc_rows, &mpmc_rows, &output)?;
     println!("wrote {}", output.display());
@@ -191,10 +200,6 @@ fn read_rows_for_run(
         });
     }
     select_run_with_default_mode(rows, requested_run, default_mode)
-}
-
-fn select_run(rows: Vec<Row>, requested_run: Option<String>) -> ChartResult<Vec<Row>> {
-    select_run_with_default_mode(rows, requested_run, None)
 }
 
 fn select_run_with_default_mode(
@@ -287,7 +292,7 @@ mod tests {
     use super::{Row, select_run_with_default_mode};
 
     #[test]
-    fn summary_default_ignores_newer_blocking_run() {
+    fn chart_default_ignores_newer_blocking_run() {
         let rows = vec![row("try-run", "try"), row("blocking-run", "blocking")];
 
         let selected = select_run_with_default_mode(rows, None, Some("try")).unwrap();

--- a/src/bin/chart.rs
+++ b/src/bin/chart.rs
@@ -171,25 +171,37 @@ fn run_summary() -> ChartResult<()> {
     let output = arg_value("--output")
         .map_or_else(|| PathBuf::from("doc/charts/summary.svg"), PathBuf::from);
 
-    let mpsc_rows = read_rows_for_run(&mpsc_input, arg_value("--mpsc-run"))?;
-    let mpmc_rows = read_rows_for_run(&mpmc_input, arg_value("--mpmc-run"))?;
+    let mpsc_rows = read_rows_for_run(&mpsc_input, arg_value("--mpsc-run"), Some("try"))?;
+    let mpmc_rows = read_rows_for_run(&mpmc_input, arg_value("--mpmc-run"), Some("try"))?;
     prepare_output(&output)?;
     draw_summary_chart(&mpsc_rows, &mpmc_rows, &output)?;
     println!("wrote {}", output.display());
     Ok(())
 }
 
-fn read_rows_for_run(path: &Path, requested_run: Option<String>) -> ChartResult<Vec<Row>> {
+fn read_rows_for_run(
+    path: &Path,
+    requested_run: Option<String>,
+    default_mode: Option<&str>,
+) -> ChartResult<Vec<Row>> {
     let rows = read_rows(path)?;
     if rows.is_empty() {
         return Err(ChartError::NoRows {
             path: path.to_path_buf(),
         });
     }
-    select_run(rows, requested_run)
+    select_run_with_default_mode(rows, requested_run, default_mode)
 }
 
 fn select_run(rows: Vec<Row>, requested_run: Option<String>) -> ChartResult<Vec<Row>> {
+    select_run_with_default_mode(rows, requested_run, None)
+}
+
+fn select_run_with_default_mode(
+    rows: Vec<Row>,
+    requested_run: Option<String>,
+    default_mode: Option<&str>,
+) -> ChartResult<Vec<Row>> {
     let run_id = if let Some(run_id) = requested_run {
         run_id
     } else {
@@ -197,12 +209,12 @@ fn select_run(rows: Vec<Row>, requested_run: Option<String>) -> ChartResult<Vec<
             .rev()
             .map(|row| row.run_id.as_str())
             .find(|run_id| {
-                run_is_complete(
-                    &rows
-                        .iter()
-                        .filter(|row| row.run_id == **run_id)
-                        .collect::<Vec<_>>(),
-                )
+                let run_rows = rows
+                    .iter()
+                    .filter(|row| row.run_id == **run_id)
+                    .collect::<Vec<_>>();
+                run_is_complete(&run_rows)
+                    && default_mode.is_none_or(|mode| run_rows.iter().all(|row| row.mode == mode))
             })
             .map(str::to_owned)
             .ok_or(ChartError::NoCompleteRun)?
@@ -268,4 +280,38 @@ fn read_rows(path: &Path) -> ChartResult<Vec<Row>> {
         }
     }
     Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Row, select_run_with_default_mode};
+
+    #[test]
+    fn summary_default_ignores_newer_blocking_run() {
+        let rows = vec![row("try-run", "try"), row("blocking-run", "blocking")];
+
+        let selected = select_run_with_default_mode(rows, None, Some("try")).unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].run_id, "try-run");
+    }
+
+    fn row(run_id: &str, mode: &str) -> Row {
+        Row {
+            run_id: run_id.to_string(),
+            cpu: "cpu".to_string(),
+            mode: mode.to_string(),
+            implementation: "fanring".to_string(),
+            payload: "u64".to_string(),
+            payload_bytes: 8,
+            producers: 1,
+            consumers: None,
+            nominal_capacity: 1,
+            capacity_model: Some("per-ring-hwm".to_string()),
+            items_per_sec: 1.0,
+            sample: 0,
+            samples: 1,
+            expected_rows: 1,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! Fast typed in-process MPSC and MPMC channels built from SPSC rings.
 //!
 //! Every sender owns one bounded ring. Producers therefore avoid contention on
@@ -9,8 +11,7 @@
 //! - [`mpsc`] has one receiver, preserves FIFO within each sender lane, and has
 //!   the smallest receive-side overhead.
 //! - [`mpmc`] has cloneable competing receivers and relaxed ordering. Receivers
-//!   stage batches in stealable local FIFOs, so total resident work can exceed
-//!   the sum of sender-ring capacities.
+//!   stage batches in bounded lock-free queues that other receivers can steal.
 //!
 //! Both variants provide nonblocking, blocking, timeout, and deadline APIs.
 //! Capacity is a high-water mark per sender, not one shared channel bound.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! - [`mpsc`] has one receiver, preserves FIFO within each sender lane, and has
 //!   the smallest receive-side overhead.
 //! - [`mpmc`] has cloneable competing receivers and relaxed ordering. Receivers
-//!   stage batches in bounded lock-free queues that other receivers can steal.
+//!   stage batches in bounded queues that other receivers can steal.
 //!
 //! Both variants provide nonblocking, blocking, timeout, and deadline APIs.
 //! Capacity is a high-water mark per sender, not one shared channel bound.

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -113,6 +113,9 @@ fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
             shared,
             id: 0,
             local,
+            private: std::cell::RefCell::new(std::collections::VecDeque::with_capacity(
+                PREFETCH_LIMIT,
+            )),
             steal_cursor: 0,
             ready: std::cell::RefCell::new(ready),
             seen_ready_generation: std::cell::Cell::new(0),

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1,15 +1,13 @@
 //! Dynamic MPMC channel built from one bounded SPSC ring per sender.
 //!
-//! Senders never contend on a shared queue tail. A receiver drains up to 64
-//! values from a ready ring, returns one, and publishes the rest to its local
-//! stealable FIFO. Other receivers can steal that work in batches. Ordering is
-//! relaxed.
+//! Senders never contend on a shared queue tail. Receivers drain ready rings
+//! into bounded local queues whose work can be stolen in batches by competing
+//! receivers. Ordering is relaxed.
 
 use std::fmt;
 
 use arc_swap::ArcSwap;
 use concurrent_queue::ConcurrentQueue;
-use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 
 use crate::compat::{Arc, AtomicBool, AtomicUsize, Mutex, Ordering, lock};
 use crate::config::validate_capacity;
@@ -19,10 +17,12 @@ use crate::wait::MultiWaitCell;
 
 mod receiver;
 mod sender;
+mod work;
 
 use receiver::{FinishLane, Lane, LaneToken, close_lane};
 pub use receiver::{IntoIter, Iter, Receiver, TryIter};
 pub use sender::Sender;
+use work::WorkQueue;
 
 pub use crate::error::{
     ChannelError, RecvError, RecvTimeoutError, SendError, SendTimeoutError, TryRecvError,
@@ -80,17 +80,19 @@ fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
         slot: 0,
         generation: 0,
     };
-    let local = Worker::new_fifo();
-    let stealer = local.stealer();
-    let mut registry = Registry::new(group, work_group, lane_page, stealer.clone());
+    let local = WorkQueue::bounded(PREFETCH_LIMIT);
+    let mut registry = Registry::new(group, work_group, lane_page, local.clone());
     registry.install_lane(LaneToken::new(Lane::new(key, signal.clone(), consumer)));
     let ready = std::sync::Arc::new(registry.clone_ready_topology());
     let shared = Arc::new(Shared {
         registry: Mutex::new(registry),
-        stealers: ArcSwap::from_pointee(vec![(0, stealer)]),
+        #[cfg(not(loom))]
+        work_queues: ArcSwap::from_pointee(vec![(0, local.clone())]),
+        #[cfg(loom)]
+        work_queues: Mutex::new(vec![(0, local.clone())]),
         ready: ArcSwap::new(ready.clone()),
         ready_generation: AtomicUsize::new(0),
-        injector: Injector::new(),
+        orphaned_work: WorkQueue::unbounded(),
         publications: PublicationTracker::new(),
         registered_lanes: AtomicUsize::new(1),
         live_senders: AtomicUsize::new(1),
@@ -125,10 +127,13 @@ fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
 
 struct Shared<T> {
     registry: Mutex<Registry<T>>,
-    stealers: ArcSwap<Vec<(usize, Stealer<T>)>>,
+    #[cfg(not(loom))]
+    work_queues: ArcSwap<Vec<(usize, WorkQueue<T>)>>,
+    #[cfg(loom)]
+    work_queues: Mutex<Vec<(usize, WorkQueue<T>)>>,
     ready: ArcSwap<ReadyTopology<T>>,
     ready_generation: AtomicUsize,
-    injector: Injector<T>,
+    orphaned_work: WorkQueue<T>,
     publications: PublicationTracker,
     registered_lanes: AtomicUsize,
     live_senders: AtomicUsize,
@@ -167,13 +172,17 @@ impl<T> Shared<T> {
         Ok((key, signal, producer))
     }
 
-    fn register_receiver(&self) -> (usize, Worker<T>) {
-        let local = Worker::new_fifo();
-        let stealer = local.stealer();
+    fn register_receiver(&self) -> (usize, WorkQueue<T>) {
+        let local = WorkQueue::bounded(PREFETCH_LIMIT);
         let mut registry = lock(&self.registry);
-        let id = registry.register_receiver(stealer);
-        self.stealers
-            .store(std::sync::Arc::new(registry.clone_stealers()));
+        let id = registry.register_receiver(local.clone());
+        #[cfg(not(loom))]
+        self.work_queues
+            .store(std::sync::Arc::new(registry.clone_work_queues()));
+        #[cfg(loom)]
+        {
+            *lock(&self.work_queues) = registry.clone_work_queues();
+        }
         drop(registry);
         self.live_receivers.fetch_add(1, Ordering::AcqRel);
         self.publications.notify_change();
@@ -183,8 +192,13 @@ impl<T> Shared<T> {
     fn unregister_receiver(&self, id: usize) {
         let mut registry = lock(&self.registry);
         registry.unregister_receiver(id);
-        self.stealers
-            .store(std::sync::Arc::new(registry.clone_stealers()));
+        #[cfg(not(loom))]
+        self.work_queues
+            .store(std::sync::Arc::new(registry.clone_work_queues()));
+        #[cfg(loom)]
+        {
+            *lock(&self.work_queues) = registry.clone_work_queues();
+        }
         drop(registry);
         self.publications.notify_change();
     }
@@ -248,13 +262,7 @@ impl<T> Shared<T> {
                 close_lane(lane);
             }
         }
-        loop {
-            match self.injector.steal() {
-                Steal::Success(value) => drop(value),
-                Steal::Retry => {}
-                Steal::Empty => break,
-            }
-        }
+        while self.orphaned_work.pop().is_some() {}
         self.data_waiters.notify_all();
     }
 }
@@ -352,7 +360,7 @@ struct Registry<T> {
     groups: Vec<Arc<ReadyGroup>>,
     work_groups: Vec<Arc<ReadyGroup>>,
     pages: Vec<Arc<LanePage<T>>>,
-    stealers: Vec<Option<Stealer<T>>>,
+    work_queues: Vec<Option<WorkQueue<T>>>,
     free_receivers: Vec<usize>,
 }
 
@@ -361,7 +369,7 @@ impl<T> Registry<T> {
         group: Arc<ReadyGroup>,
         work_group: Arc<ReadyGroup>,
         page: Arc<LanePage<T>>,
-        stealer: Stealer<T>,
+        work_queue: WorkQueue<T>,
     ) -> Self {
         Self {
             slots: vec![Slot {
@@ -372,34 +380,34 @@ impl<T> Registry<T> {
             groups: vec![group],
             work_groups: vec![work_group],
             pages: vec![page],
-            stealers: vec![Some(stealer)],
+            work_queues: vec![Some(work_queue)],
             free_receivers: Vec::new(),
         }
     }
 
-    fn register_receiver(&mut self, stealer: Stealer<T>) -> usize {
+    fn register_receiver(&mut self, work_queue: WorkQueue<T>) -> usize {
         if let Some(id) = self.free_receivers.pop() {
-            debug_assert!(self.stealers[id].is_none());
-            self.stealers[id] = Some(stealer);
+            debug_assert!(self.work_queues[id].is_none());
+            self.work_queues[id] = Some(work_queue);
             id
         } else {
-            let id = self.stealers.len();
-            self.stealers.push(Some(stealer));
+            let id = self.work_queues.len();
+            self.work_queues.push(Some(work_queue));
             id
         }
     }
 
     fn unregister_receiver(&mut self, id: usize) {
-        if self.stealers[id].take().is_some() {
+        if self.work_queues[id].take().is_some() {
             self.free_receivers.push(id);
         }
     }
 
-    fn clone_stealers(&self) -> Vec<(usize, Stealer<T>)> {
-        self.stealers
+    fn clone_work_queues(&self) -> Vec<(usize, WorkQueue<T>)> {
+        self.work_queues
             .iter()
             .enumerate()
-            .filter_map(|(id, stealer)| stealer.clone().map(|stealer| (id, stealer)))
+            .filter_map(|(id, queue)| queue.clone().map(|queue| (id, queue)))
             .collect()
     }
 

--- a/src/mpmc/receiver.rs
+++ b/src/mpmc/receiver.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
@@ -19,6 +20,8 @@ pub struct Receiver<T> {
     pub(super) shared: Arc<Shared<T>>,
     pub(super) id: usize,
     pub(super) local: super::WorkQueue<T>,
+    /// Unsynchronized staging used only while this is the sole receiver.
+    pub(super) private: RefCell<VecDeque<T>>,
     pub(super) steal_cursor: usize,
     pub(super) ready: RefCell<std::sync::Arc<ReadyTopology<T>>>,
     pub(super) seen_ready_generation: Cell<usize>,
@@ -31,12 +34,17 @@ pub struct Receiver<T> {
 
 impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
+        // Make sole-receiver staging stealable before publishing another clone.
+        let publication = self.shared.publications.begin();
+        self.local.push_batch(self.private.borrow_mut().drain(..));
         let (id, local) = self.shared.register_receiver();
+        drop(publication);
         let (ready, seen_ready_generation) = self.shared.ready_snapshot();
         Self {
             shared: self.shared.clone(),
             id,
             local,
+            private: RefCell::new(VecDeque::with_capacity(PREFETCH_LIMIT)),
             steal_cursor: 0,
             ready: RefCell::new(ready),
             seen_ready_generation: Cell::new(seen_ready_generation),
@@ -104,6 +112,9 @@ impl<T> Receiver<T> {
     }
 
     fn pop_work(&mut self) -> WorkPop<T> {
+        if let Some(value) = self.private.get_mut().pop_front() {
+            return WorkPop::Item(value);
+        }
         if let Some(value) = self.local.pop() {
             return WorkPop::Item(value);
         }
@@ -419,12 +430,19 @@ impl<T> Receiver<T> {
             .consumer
             .pop()
             .expect("cached_available guarantees prefetched data");
-        for _ in 1..batch {
-            self.local.push(
+        // Only this receiver can create a second clone while the count is one.
+        if self.shared.live_receivers.load(Ordering::Acquire) == 1 {
+            self.private.borrow_mut().extend((1..batch).map(|_| {
                 lane.consumer
                     .pop()
-                    .expect("batch is bounded by cached availability"),
-            );
+                    .expect("batch is bounded by cached availability")
+            }));
+        } else {
+            self.local.push_batch((1..batch).map(|_| {
+                lane.consumer
+                    .pop()
+                    .expect("batch is bounded by cached availability")
+            }));
         }
         lane.cached_available -= batch;
         lane.unreleased += batch;
@@ -540,7 +558,10 @@ impl<T> Receiver<T> {
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         let publication = self.shared.publications.begin();
-        let published = self.local.drain_into(&self.shared.orphaned_work);
+        let private = self.private.get_mut();
+        let mut published = !private.is_empty();
+        self.shared.orphaned_work.push_batch(private.drain(..));
+        published |= self.local.drain_into(&self.shared.orphaned_work);
         self.shared.unregister_receiver(self.id);
         drop(publication);
 
@@ -557,7 +578,10 @@ impl<T> fmt::Debug for Receiver<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver")
             .field("id", &self.id)
-            .field("local_items", &self.local.len())
+            .field(
+                "local_items",
+                &(self.private.borrow().len() + self.local.len()),
+            )
             .field(
                 "registered_lanes",
                 &self.shared.registered_lanes.load(Ordering::Relaxed),

--- a/src/mpmc/receiver.rs
+++ b/src/mpmc/receiver.rs
@@ -3,8 +3,6 @@ use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
 
-use crossbeam_deque::{Steal, Worker};
-
 use crate::compat::{Arc, Ordering};
 use crate::publication::Publication;
 use crate::ready::{LaneSignal, PAGES_PER_GROUP};
@@ -16,12 +14,11 @@ use super::{
 
 /// Receiving half.
 ///
-/// Clones compete for messages. Each receiver has a local work queue whose
-/// buffered items remain stealable by other receivers.
+/// Clones compete for messages through bounded stealable work queues.
 pub struct Receiver<T> {
     pub(super) shared: Arc<Shared<T>>,
     pub(super) id: usize,
-    pub(super) local: Worker<T>,
+    pub(super) local: super::WorkQueue<T>,
     pub(super) steal_cursor: usize,
     pub(super) ready: RefCell<std::sync::Arc<ReadyTopology<T>>>,
     pub(super) seen_ready_generation: Cell<usize>,
@@ -77,22 +74,11 @@ impl<T> Receiver<T> {
     #[inline]
     fn try_recv_inner(&mut self) -> (Result<T, TryRecvError>, Effects) {
         for attempt in 0..=TRY_RECV_RETRIES {
-            let (work_generation, work_contended) = match self.pop_work() {
+            let work_generation = match self.pop_work() {
                 WorkPop::Item(value) => return (Ok(value), Effects::default()),
-                WorkPop::Empty {
-                    generation,
-                    contended,
-                } => (generation, contended),
+                WorkPop::Empty { generation } => generation,
             };
-
             let Some((lane, publication)) = self.acquire_lane() else {
-                if work_contended {
-                    if attempt != TRY_RECV_RETRIES {
-                        std::hint::spin_loop();
-                        continue;
-                    }
-                    return (Err(TryRecvError::Empty), Effects::default());
-                }
                 match self.empty_scan_state(work_generation) {
                     EmptyScan::Changed if attempt != TRY_RECV_RETRIES => continue,
                     EmptyScan::Changed | EmptyScan::Publishing | EmptyScan::Open => {
@@ -115,6 +101,51 @@ impl<T> Receiver<T> {
             }
         }
         (Err(TryRecvError::Empty), Effects::default())
+    }
+
+    fn pop_work(&mut self) -> WorkPop<T> {
+        if let Some(value) = self.local.pop() {
+            return WorkPop::Item(value);
+        }
+
+        let generation = self.shared.publications.snapshot();
+        if let Some(value) = self.shared.orphaned_work.pop() {
+            return WorkPop::Item(value);
+        }
+        if self.has_ready_lane() {
+            return WorkPop::Empty { generation };
+        }
+
+        #[cfg(not(loom))]
+        let work_queues = self.shared.work_queues.load();
+        #[cfg(loom)]
+        let work_queues = crate::compat::lock(&self.shared.work_queues);
+        let len = work_queues.len();
+        for offset in 0..len {
+            let index = (self.steal_cursor + offset) % len;
+            let (id, queue) = &work_queues[index];
+            if *id == self.id || queue.len() == 0 {
+                continue;
+            }
+            let publication = self.shared.publications.begin();
+            let stolen = queue.steal_batch_into(&self.local);
+            drop(publication);
+            if let Some(value) = stolen {
+                self.steal_cursor = index.wrapping_add(1);
+                return WorkPop::Item(value);
+            }
+        }
+        if len != 0 {
+            self.steal_cursor = self.steal_cursor.wrapping_add(1) % len;
+        }
+        WorkPop::Empty { generation }
+    }
+
+    fn has_ready_lane(&self) -> bool {
+        self.refresh_ready_topology();
+        let ready = self.ready.borrow();
+        ready.ready_groups.iter().any(|group| group.has_ready())
+            || ready.work_groups.iter().any(|group| group.has_ready())
     }
 
     #[inline]
@@ -260,45 +291,6 @@ impl<T> Receiver<T> {
                     Err(TryRecvError::Empty) => return Err(RecvTimeoutError::Timeout),
                 }
             }
-        }
-    }
-
-    fn pop_work(&mut self) -> WorkPop<T> {
-        if let Some(value) = self.local.pop() {
-            return WorkPop::Item(value);
-        }
-
-        let generation = self.shared.publications.snapshot();
-        let mut contended = false;
-        match self.shared.injector.steal_batch_and_pop(&self.local) {
-            Steal::Success(value) => return WorkPop::Item(value),
-            Steal::Retry => contended = true,
-            Steal::Empty => {}
-        }
-
-        let stealers = self.shared.stealers.load();
-        let len = stealers.len();
-        for offset in 0..len {
-            let index = (self.steal_cursor + offset) % len;
-            let (id, stealer) = &stealers[index];
-            if *id == self.id {
-                continue;
-            }
-            match stealer.steal_batch_and_pop(&self.local) {
-                Steal::Success(value) => {
-                    self.steal_cursor = index.wrapping_add(1);
-                    return WorkPop::Item(value);
-                }
-                Steal::Retry => contended = true,
-                Steal::Empty => {}
-            }
-        }
-        if len != 0 {
-            self.steal_cursor = self.steal_cursor.wrapping_add(1) % len;
-        }
-        WorkPop::Empty {
-            generation,
-            contended,
         }
     }
 
@@ -548,11 +540,7 @@ impl<T> Receiver<T> {
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         let publication = self.shared.publications.begin();
-        let mut published = false;
-        while let Some(value) = self.local.pop() {
-            self.shared.injector.push(value);
-            published = true;
-        }
+        let published = self.local.drain_into(&self.shared.orphaned_work);
         self.shared.unregister_receiver(self.id);
         drop(publication);
 
@@ -731,7 +719,7 @@ enum LaneDrain<T> {
 
 enum WorkPop<T> {
     Item(T),
-    Empty { generation: usize, contended: bool },
+    Empty { generation: usize },
 }
 
 enum EmptyScan {

--- a/src/mpmc/work.rs
+++ b/src/mpmc/work.rs
@@ -4,15 +4,20 @@
 //! and move a small batch into their own queue. The shared unbounded queue only
 //! preserves staged values when a receiver is dropped.
 
-use concurrent_queue::ConcurrentQueue;
+use std::collections::VecDeque;
 
-use crate::compat::Arc;
+use crate::compat::{Arc, Mutex, lock};
 
 const STEAL_BATCH_LIMIT: usize = 8;
 
-/// Cloneable handle to a lock-free queue of staged receiver work.
+/// Cloneable handle to a synchronized queue of staged receiver work.
 pub(super) struct WorkQueue<T> {
-    queue: Arc<ConcurrentQueue<T>>,
+    queue: Arc<Queue<T>>,
+}
+
+struct Queue<T> {
+    values: Mutex<VecDeque<T>>,
+    capacity: Option<usize>,
 }
 
 impl<T> Clone for WorkQueue<T> {
@@ -27,14 +32,20 @@ impl<T> WorkQueue<T> {
     /// Create a bounded queue for one receiver's prefetched values.
     pub(super) fn bounded(capacity: usize) -> Self {
         Self {
-            queue: Arc::new(ConcurrentQueue::bounded(capacity)),
+            queue: Arc::new(Queue {
+                values: Mutex::new(VecDeque::with_capacity(capacity)),
+                capacity: Some(capacity),
+            }),
         }
     }
 
     /// Create the shared unbounded queue used during receiver removal.
     pub(super) fn unbounded() -> Self {
         Self {
-            queue: Arc::new(ConcurrentQueue::unbounded()),
+            queue: Arc::new(Queue {
+                values: Mutex::new(VecDeque::new()),
+                capacity: None,
+            }),
         }
     }
 
@@ -42,17 +53,32 @@ impl<T> WorkQueue<T> {
     ///
     /// Bounded queues rely on the invariant that a receiver stages at most one
     /// prefetch batch while its queue is empty.
+    #[cfg(test)]
     #[inline]
     pub(super) fn push(&self, value: T) {
-        if self.queue.push(value).is_err() {
-            unreachable!("work queue capacity matches the maximum staged batch");
+        self.push_batch(std::iter::once(value));
+    }
+
+    /// Append a batch while acquiring the queue once.
+    #[inline]
+    pub(super) fn push_batch(&self, values: impl IntoIterator<Item = T>) {
+        let mut queue = lock(&self.queue.values);
+        for value in values {
+            if self
+                .queue
+                .capacity
+                .is_some_and(|capacity| queue.len() >= capacity)
+            {
+                unreachable!("work queue capacity matches the maximum staged batch");
+            }
+            queue.push_back(value);
         }
     }
 
     /// Remove one staged value, or return `None` when the queue is empty.
     #[inline]
     pub(super) fn pop(&self) -> Option<T> {
-        self.queue.pop().ok()
+        lock(&self.queue.values).pop_front()
     }
 
     /// Steal one value and move part of the remaining work to `destination`.
@@ -60,14 +86,17 @@ impl<T> WorkQueue<T> {
     /// The returned value satisfies the current receive. At most seven more
     /// values move to the thief, bounding work performed by one steal.
     pub(super) fn steal_batch_into(&self, destination: &Self) -> Option<T> {
-        let value = self.pop()?;
-        let transfer = self.queue.len().div_ceil(2).min(STEAL_BATCH_LIMIT - 1);
-        for _ in 0..transfer {
-            let Some(stolen) = self.pop() else {
-                break;
-            };
-            destination.push(stolen);
-        }
+        let (value, stolen) = {
+            let mut source = lock(&self.queue.values);
+            let value = source.pop_front()?;
+            let transfer = source.len().div_ceil(2).min(STEAL_BATCH_LIMIT - 1);
+            let mut stolen = std::array::from_fn::<_, { STEAL_BATCH_LIMIT - 1 }, _>(|_| None);
+            for slot in &mut stolen[..transfer] {
+                *slot = source.pop_front();
+            }
+            (value, stolen)
+        };
+        destination.push_batch(stolen.into_iter().flatten());
         Some(value)
     }
 
@@ -75,18 +104,19 @@ impl<T> WorkQueue<T> {
     ///
     /// Returns whether at least one value moved.
     pub(super) fn drain_into(&self, destination: &Self) -> bool {
-        let mut moved = false;
-        while let Some(value) = self.pop() {
-            destination.push(value);
-            moved = true;
-        }
+        let drained = {
+            let mut source = lock(&self.queue.values);
+            std::mem::take(&mut *source)
+        };
+        let moved = !drained.is_empty();
+        destination.push_batch(drained);
         moved
     }
 
     /// Return an instantaneous queue-length estimate.
     #[inline]
     pub(super) fn len(&self) -> usize {
-        self.queue.len()
+        lock(&self.queue.values).len()
     }
 }
 

--- a/src/mpmc/work.rs
+++ b/src/mpmc/work.rs
@@ -181,6 +181,35 @@ mod loom_tests {
         });
     }
 
+    #[test]
+    fn drain_racing_steal_preserves_every_value() {
+        loom::model(|| {
+            let source = WorkQueue::bounded(2);
+            source.push(1);
+            source.push(2);
+
+            let orphaned = WorkQueue::unbounded();
+            let drain_source = source.clone();
+            let drain_orphaned = orphaned.clone();
+            let drain = thread::spawn(move || {
+                drain_source.drain_into(&drain_orphaned);
+            });
+            let steal_source = source.clone();
+            let steal = thread::spawn(move || drain_steal(&steal_source));
+
+            drain.join().unwrap();
+            let mut values = steal.join().unwrap();
+            while let Some(value) = source.pop() {
+                values.push(value);
+            }
+            while let Some(value) = orphaned.pop() {
+                values.push(value);
+            }
+            values.sort_unstable();
+            assert_eq!(values, [1, 2]);
+        });
+    }
+
     fn drain_steal(source: &WorkQueue<usize>) -> Vec<usize> {
         let destination = WorkQueue::bounded(2);
         let mut values = source

--- a/src/mpmc/work.rs
+++ b/src/mpmc/work.rs
@@ -1,0 +1,195 @@
+//! Receiver-local staging and batch stealing for the MPMC channel.
+//!
+//! Each receiver owns one bounded queue. Competing receivers may pop from it
+//! and move a small batch into their own queue. The shared unbounded queue only
+//! preserves staged values when a receiver is dropped.
+
+use concurrent_queue::ConcurrentQueue;
+
+use crate::compat::Arc;
+
+const STEAL_BATCH_LIMIT: usize = 8;
+
+/// Cloneable handle to a lock-free queue of staged receiver work.
+pub(super) struct WorkQueue<T> {
+    queue: Arc<ConcurrentQueue<T>>,
+}
+
+impl<T> Clone for WorkQueue<T> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue.clone(),
+        }
+    }
+}
+
+impl<T> WorkQueue<T> {
+    /// Create a bounded queue for one receiver's prefetched values.
+    pub(super) fn bounded(capacity: usize) -> Self {
+        Self {
+            queue: Arc::new(ConcurrentQueue::bounded(capacity)),
+        }
+    }
+
+    /// Create the shared unbounded queue used during receiver removal.
+    pub(super) fn unbounded() -> Self {
+        Self {
+            queue: Arc::new(ConcurrentQueue::unbounded()),
+        }
+    }
+
+    /// Append one staged value.
+    ///
+    /// Bounded queues rely on the invariant that a receiver stages at most one
+    /// prefetch batch while its queue is empty.
+    #[inline]
+    pub(super) fn push(&self, value: T) {
+        if self.queue.push(value).is_err() {
+            unreachable!("work queue capacity matches the maximum staged batch");
+        }
+    }
+
+    /// Remove one staged value, or return `None` when the queue is empty.
+    #[inline]
+    pub(super) fn pop(&self) -> Option<T> {
+        self.queue.pop().ok()
+    }
+
+    /// Steal one value and move part of the remaining work to `destination`.
+    ///
+    /// The returned value satisfies the current receive. At most seven more
+    /// values move to the thief, bounding work performed by one steal.
+    pub(super) fn steal_batch_into(&self, destination: &Self) -> Option<T> {
+        let value = self.pop()?;
+        let transfer = self.queue.len().div_ceil(2).min(STEAL_BATCH_LIMIT - 1);
+        for _ in 0..transfer {
+            let Some(stolen) = self.pop() else {
+                break;
+            };
+            destination.push(stolen);
+        }
+        Some(value)
+    }
+
+    /// Move every currently reachable value to `destination`.
+    ///
+    /// Returns whether at least one value moved.
+    pub(super) fn drain_into(&self, destination: &Self) -> bool {
+        let mut moved = false;
+        while let Some(value) = self.pop() {
+            destination.push(value);
+            moved = true;
+        }
+        moved
+    }
+
+    /// Return an instantaneous queue-length estimate.
+    #[inline]
+    pub(super) fn len(&self) -> usize {
+        self.queue.len()
+    }
+}
+
+impl<T> std::fmt::Debug for WorkQueue<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkQueue")
+            .field("len", &self.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(all(test, not(loom)))]
+mod tests {
+    use super::WorkQueue;
+
+    #[test]
+    fn steal_returns_one_and_moves_half_the_remainder() {
+        let source = WorkQueue::bounded(8);
+        let destination = WorkQueue::bounded(8);
+        for value in 0..7 {
+            source.push(value);
+        }
+
+        assert_eq!(source.steal_batch_into(&destination), Some(0));
+        assert_eq!(source.len(), 3);
+        assert_eq!(destination.len(), 3);
+
+        let mut values = Vec::new();
+        while let Some(value) = source.pop() {
+            values.push(value);
+        }
+        while let Some(value) = destination.pop() {
+            values.push(value);
+        }
+        values.sort_unstable();
+        assert_eq!(values, (1..7).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn steal_batch_is_capped_at_eight_values() {
+        let source = WorkQueue::bounded(64);
+        let destination = WorkQueue::bounded(64);
+        for value in 0..64 {
+            source.push(value);
+        }
+
+        assert_eq!(source.steal_batch_into(&destination), Some(0));
+        assert_eq!(source.len(), 56);
+        assert_eq!(destination.len(), 7);
+    }
+
+    #[test]
+    fn drain_moves_every_value() {
+        let source = WorkQueue::bounded(4);
+        let destination = WorkQueue::unbounded();
+        for value in 0..4 {
+            source.push(value);
+        }
+
+        assert!(source.drain_into(&destination));
+        assert_eq!(source.len(), 0);
+        assert_eq!(destination.len(), 4);
+        assert!(!source.drain_into(&destination));
+    }
+}
+
+#[cfg(all(test, loom, target_pointer_width = "64"))]
+mod loom_tests {
+    use loom::thread;
+
+    use super::WorkQueue;
+
+    #[test]
+    fn concurrent_steals_preserve_every_value() {
+        loom::model(|| {
+            let source = WorkQueue::bounded(2);
+            source.push(1);
+            source.push(2);
+
+            let first_source = source.clone();
+            let first = thread::spawn(move || drain_steal(&first_source));
+            let second_source = source.clone();
+            let second = thread::spawn(move || drain_steal(&second_source));
+
+            let mut values = first.join().unwrap();
+            values.extend(second.join().unwrap());
+            while let Some(value) = source.pop() {
+                values.push(value);
+            }
+            values.sort_unstable();
+            assert_eq!(values, [1, 2]);
+        });
+    }
+
+    fn drain_steal(source: &WorkQueue<usize>) -> Vec<usize> {
+        let destination = WorkQueue::bounded(2);
+        let mut values = source
+            .steal_batch_into(&destination)
+            .into_iter()
+            .collect::<Vec<_>>();
+        while let Some(value) = destination.pop() {
+            values.push(value);
+        }
+        values
+    }
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -561,6 +561,142 @@ fn mpmc_receiver_drop_preserves_prefetched_work() {
 }
 
 #[test]
+fn mpmc_clone_makes_private_prefetch_competitive() {
+    model(|| {
+        let (mut tx, mut rx0) = mpmc::channel(2);
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        drop(tx);
+        assert_eq!(rx0.recv(), Ok(1));
+
+        let mut rx1 = rx0.clone();
+        let first = thread::spawn(move || rx0.recv());
+        let second = thread::spawn(move || rx1.recv());
+        let results = [first.join().unwrap(), second.join().unwrap()];
+
+        assert_eq!(results.iter().filter(|result| result == &&Ok(2)).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| result == &&Err(mpmc::RecvError))
+                .count(),
+            1
+        );
+    });
+}
+
+#[test]
+fn mpmc_owner_drop_racing_private_prefetch_steal_preserves_work() {
+    model(|| {
+        let (mut tx, mut rx0) = mpmc::channel(2);
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        drop(tx);
+        assert_eq!(rx0.recv(), Ok(1));
+
+        let mut rx1 = rx0.clone();
+        let thief = thread::spawn(move || rx1.recv());
+        thread::yield_now();
+        drop(rx0);
+
+        assert_eq!(thief.join().unwrap(), Ok(2));
+    });
+}
+
+#[test]
+fn mpmc_last_competitor_drop_racing_prefetch_preserves_work() {
+    model(|| {
+        let (mut tx, mut rx0) = mpmc::channel(2);
+        let rx1 = rx0.clone();
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        drop(tx);
+
+        let dropper = thread::spawn(move || drop(rx1));
+        assert_eq!(rx0.recv(), Ok(1));
+        dropper.join().unwrap();
+
+        let mut rx2 = rx0.clone();
+        drop(rx0);
+        assert_eq!(rx2.recv(), Ok(2));
+        assert_eq!(rx2.try_recv(), Err(mpmc::TryRecvError::Disconnected));
+    });
+}
+
+#[test]
+fn mpmc_shared_to_private_staging_transition_preserves_work() {
+    model(|| {
+        let (mut tx, mut rx0) = mpmc::channel(2);
+        let rx1 = rx0.clone();
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        assert_eq!(rx0.recv(), Ok(1));
+
+        let dropper = thread::spawn(move || drop(rx1));
+        dropper.join().unwrap();
+        assert_eq!(rx0.recv(), Ok(2));
+
+        tx.try_send(3).unwrap();
+        tx.try_send(4).unwrap();
+        drop(tx);
+        assert_eq!(rx0.recv(), Ok(3));
+
+        let mut rx2 = rx0.clone();
+        drop(rx0);
+        assert_eq!(rx2.recv(), Ok(4));
+        assert_eq!(rx2.try_recv(), Err(mpmc::TryRecvError::Disconnected));
+    });
+}
+
+#[test]
+fn mpmc_unregister_register_race_preserves_staged_work() {
+    model(|| {
+        let (mut tx, mut rx0) = mpmc::channel(2);
+        let rx1 = rx0.clone();
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        drop(tx);
+        assert_eq!(rx0.recv(), Ok(1));
+
+        let dropper = thread::spawn(move || drop(rx1));
+        let mut rx2 = rx0.clone();
+        dropper.join().unwrap();
+        drop(rx0);
+
+        assert_eq!(rx2.recv(), Ok(2));
+        assert_eq!(rx2.try_recv(), Err(mpmc::TryRecvError::Disconnected));
+    });
+}
+
+#[test]
+fn mpmc_owner_drop_and_two_thieves_preserve_shared_work() {
+    model(|| {
+        let (mut tx, mut rx0) = mpmc::channel(2);
+        let mut rx1 = rx0.clone();
+        let mut rx2 = rx0.clone();
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        drop(tx);
+        assert_eq!(rx0.recv(), Ok(1));
+
+        let first = thread::spawn(move || rx1.recv());
+        let second = thread::spawn(move || rx2.recv());
+        thread::yield_now();
+        drop(rx0);
+        let results = [first.join().unwrap(), second.join().unwrap()];
+
+        assert_eq!(results.iter().filter(|result| result == &&Ok(2)).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| result == &&Err(mpmc::RecvError))
+                .count(),
+            1
+        );
+    });
+}
+
+#[test]
 fn mpmc_receiver_drop_racing_steal_preserves_prefetched_work() {
     model(|| {
         let (mut tx, mut rx0) = mpmc::channel(2);

--- a/tests/mpmc_stress.rs
+++ b/tests/mpmc_stress.rs
@@ -199,6 +199,47 @@ fn stalled_receiver_does_not_strand_its_sender_lane() {
 }
 
 #[test]
+fn one_prefetched_batch_reaches_every_waiting_receiver() {
+    #[cfg(miri)]
+    const RECEIVERS: usize = 2;
+    #[cfg(not(miri))]
+    const RECEIVERS: usize = 8;
+
+    let (mut tx, rx0) = channel(RECEIVERS);
+    let mut receivers = vec![rx0];
+    for _ in 1..RECEIVERS {
+        receivers.push(receivers[0].clone());
+    }
+    let barrier = Arc::new(Barrier::new(RECEIVERS + 1));
+
+    let mut values = std::thread::scope(|scope| {
+        let handles = receivers
+            .into_iter()
+            .map(|mut rx| {
+                let barrier = barrier.clone();
+                scope.spawn(move || {
+                    barrier.wait();
+                    rx.recv_timeout(DISCONNECT_WAIT_TIMEOUT)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait();
+        for value in 0..RECEIVERS {
+            tx.try_send(value).unwrap();
+        }
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap().unwrap())
+            .collect::<Vec<_>>()
+    });
+
+    values.sort_unstable();
+    assert_eq!(values, (0..RECEIVERS).collect::<Vec<_>>());
+}
+
+#[test]
 fn busy_lane_cannot_hide_ready_lane() {
     let (mut busy, mut rx) = channel(128);
     let mut sparse = busy.try_clone().unwrap();
@@ -528,7 +569,7 @@ fn receiver_drop_racing_steal_preserves_every_value() {
 }
 
 #[test]
-fn batch_publication_never_reports_premature_disconnect() {
+fn staged_work_publication_never_reports_premature_disconnect() {
     for _ in 0..PUBLICATION_RACE_ROUNDS {
         let (mut tx, mut rx0) = channel(64);
         let mut rx1 = rx0.clone();
@@ -591,7 +632,7 @@ fn batch_publication_never_reports_premature_disconnect() {
 }
 
 #[test]
-fn batch_publication_with_live_sender_never_reports_disconnect() {
+fn staged_work_publication_with_live_sender_never_reports_disconnect() {
     for _ in 0..RACE_ROUNDS {
         let (mut tx, mut rx0) = channel(64);
         let mut rx1 = rx0.clone();


### PR DESCRIPTION
- Replace `crossbeam-deque` and `crossbeam-epoch` with bounded internal receiver work queues and capped batch stealing
- Batch synchronized queue operations and use private staging for the sole-receiver MPMC fast path
- Preserve staged values across receiver clone, drop, stealing, and disconnect publication races
- Expand Loom, stress, Miri, and sanitizer coverage for receiver topology transitions
- Keep comparison charts on complete nonblocking runs and refresh benchmark charts with current hardware data
- Document the final MPMC work-distribution and synchronization contracts