### PR TITLE
Add release-plz publishing automation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,26 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- Replaced the MPMC receiver's crossbeam work-stealing deque with internal
+  bounded work queues, batched transfers, and private sole-receiver staging.
+- Kept benchmark charts on complete nonblocking runs and refreshed comparison
+  data with explicit hardware topology metadata.
+
+### Validation
+
+- Expanded Loom coverage for receiver clone, drop, publication, topology, and
+  work-stealing races.
+- Rechecked MPMC ownership and concurrency with Miri, Tree Borrows, ThreadSanitizer,
+  randomized stress tests, and deeper bounded Loom exploration.
+
 ## [0.2.0] - 2026-09-01
 
 ### Breaking
@@ -54,5 +70,6 @@ All notable changes to this project are documented here.
 
 - Initial bounded, nonblocking MPSC implementation with a fixed sender limit.
 
+[Unreleased]: https://github.com/paddor/fanring.rs/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/paddor/fanring.rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/paddor/fanring.rs/tree/v0.1.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,7 +34,25 @@ is covered by normal stress tests and sanitizer runs.
 
 ## Release
 
-Update `Cargo.toml` and `CHANGELOG.md`, then run:
+`release-plz` runs on every push to `main`
+(`.github/workflows/release-plz.yml`). It opens or updates a release PR. After
+that PR merges, it creates an annotated `v<version>` tag, publishes to
+crates.io, and creates a GitHub release. Configuration lives in
+`release-plz.toml`; changelogs remain hand-curated.
+
+Publishing uses crates.io trusted publishing through GitHub Actions OIDC.
+Configure the trusted publisher with:
+
+```text
+GitHub owner: paddor
+GitHub repository: fanring.rs
+Workflow filename: release-plz.yml
+Environment name: (none)
+```
+
+Review the release-plz PR, verify its semver bump, and move the relevant
+`Unreleased` changelog entries into a dated version section. Before merging the
+release PR, run:
 
 ```sh
 cargo +1.93.0 test --all-features --locked
@@ -44,8 +62,8 @@ cargo package --locked
 cargo publish --dry-run --locked
 ```
 
-Publishing and tagging are separate explicit steps after review. The release
-tag is `v` followed by the package version.
+Merging the release PR is the explicit publish step. CI then tags and publishes
+the version through trusted publishing.
 
 ## Benchmarks
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_update = false
+git_tag_name = "v{{ version }}"


### PR DESCRIPTION
- Run release-plz after every update to `main`
- Grant pull request, contents, and OIDC permissions for release PRs and crates.io trusted publishing
- Preserve the existing `v<version>` tag convention for the single fanring crate
- Document release review steps and crates.io trusted-publisher fields
- Add hand-curated unreleased notes for the internal work-queue changes