### PR TITLE
Keep chart tooling out of published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "fanring"
 version = "0.2.2"
 edition = "2024"
 rust-version = "1.93"
+autobins = false
 license = "ISC"
 description = "High-throughput typed MPSC and MPMC channels with per-producer backpressure"
 repository = "https://github.com/paddor/fanring.rs"
@@ -10,10 +11,15 @@ documentation = "https://docs.rs/fanring"
 readme = "README.md"
 keywords = ["mpsc", "mpmc", "ring-buffer", "lock-free", "batching"]
 categories = ["concurrency", "data-structures"]
-include = ["src/**/*", "README.md", "LICENSE", "CHANGELOG.md", "DESIGN.md"]
-
-[package.metadata.docs.rs]
-all-features = true
+include = [
+    "src/*.rs",
+    "src/mpmc/**/*.rs",
+    "src/mpsc/**/*.rs",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "DESIGN.md",
+]
 
 [lints.rust]
 missing_debug_implementations = "deny"
@@ -27,9 +33,6 @@ check-cfg = ["cfg(loom)"]
 [dependencies]
 arc-swap = "1.7"
 concurrent-queue = { version = "2.5", features = ["loom"] }
-plotters = { version = "0.3", optional = true, default-features = false, features = ["svg_backend"] }
-serde = { version = "1", optional = true, features = ["derive"] }
-serde_json = { version = "1", optional = true }
 yring = "0.3.14"
 
 [target.'cfg(all(loom, target_pointer_width = "64"))'.dependencies]
@@ -40,12 +43,10 @@ core_affinity = "0.8.3"
 crossbeam-channel = "0.5"
 flume = "0.12"
 kanal = "0.1"
+plotters = { version = "0.3", default-features = false, features = ["svg_backend"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thingbuf = "0.1"
-
-[features]
-charts = ["dep:plotters", "dep:serde", "dep:serde_json"]
 
 [[bench]]
 name = "comparison"
@@ -62,7 +63,6 @@ name = "mpmc"
 harness = false
 test = false
 
-[[bin]]
+[[example]]
 name = "fanring-chart"
 path = "src/bin/chart.rs"
-required-features = ["charts"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -155,7 +155,7 @@ FANRING_BENCH_PROFILE=saturated cargo bench --bench comparison
 Generate an SVG from the latest benchmark run:
 
 ```sh
-cargo run --features charts --bin fanring-chart
+cargo run --example fanring-chart
 ```
 
 Default output: `doc/charts/throughput-mpsc.svg`.
@@ -168,7 +168,7 @@ Generate the two-topology summary chart from the latest complete nonblocking
 MPSC and MPMC runs:
 
 ```sh
-cargo run --features charts --bin fanring-chart -- --summary
+cargo run --example fanring-chart -- --summary
 ```
 
 Default output: `doc/charts/throughput-summary.svg`.
@@ -176,8 +176,8 @@ Default output: `doc/charts/throughput-summary.svg`.
 Generate blocking wake-latency charts from the latest complete run:
 
 ```sh
-cargo run --features charts --bin fanring-chart -- --latency mpsc
-cargo run --features charts --bin fanring-chart -- --latency mpmc
+cargo run --example fanring-chart -- --latency mpsc
+cargo run --example fanring-chart -- --latency mpmc
 ```
 
 Default outputs: `doc/charts/latency-mpsc.svg` and
@@ -196,21 +196,21 @@ postfix=6 physical cores / 12 threads, performance governor, turbo off
 Custom paths:
 
 ```sh
-cargo run --features charts --bin fanring-chart -- \
+cargo run --example fanring-chart -- \
   --input target/fanring-bench/results.jsonl \
   --output doc/charts/throughput-mpsc.svg
 
-cargo run --features charts --bin fanring-chart -- \
+cargo run --example fanring-chart -- \
   --input target/fanring-bench/mpmc.jsonl \
   --output doc/charts/throughput-mpmc.svg
 
-cargo run --features charts --bin fanring-chart -- \
+cargo run --example fanring-chart -- \
   --summary \
   --mpsc-input target/fanring-bench/results.jsonl \
   --mpmc-input target/fanring-bench/mpmc.jsonl \
   --output doc/charts/throughput-summary.svg
 
-cargo run --features charts --bin fanring-chart -- \
+cargo run --example fanring-chart -- \
   --latency mpsc \
   --input target/fanring-bench/wake-latency.jsonl \
   --run RUN_ID \


### PR DESCRIPTION
- Restrict the published package to library sources and user-facing documentation
- Convert the chart generator into a dev-only example
- Remove chart-only optional dependencies and the public `charts` feature
- Update chart-generation commands in `DEVELOPMENT.md`
- Reduce the compressed package from 53 KiB to 37 KiB