### PR TITLE
Clarify APIs and latency units

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,8 +58,8 @@ signal, ready page, and page bit:
 After flushing the yring, every publication atomically swaps the signal to
 `PENDING`. Only an `IDLE`-to-`PENDING` transition sets the lane bit in its ready
 page. A page transition from empty to nonempty sets its bit in a ready group.
-Later publications coalesce into the existing pending lane. The two-level
-bitmaps cover up to 4,096 sender lanes.
+Later publications coalesce into the existing pending lane. Each ready-group
+bitmap summarizes 4,096 sender lanes; the registry adds groups as needed.
 
 At visible empty, the receiver swaps the signal to `IDLE` and then prefetches
 the yring again. A producer that published before the swap synchronizes through

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ directly; MPMC stages prefetched batches in stealable receiver-local queues.
 
 Requires Rust 1.93 or newer.
 
+| | Nonblocking | Blocking | Timeout | Deadline |
+| --- | --- | --- | --- | --- |
+| Send | `try_send` | `send` | `send_timeout` | `send_deadline` |
+| Receive | `try_recv` | `recv` | `recv_timeout` | `recv_deadline` |
+
 ## Performance
 
 Median throughput and blocking wake latency on the system named in each

--- a/doc/charts/latency-mpmc.svg
+++ b/doc/charts/latency-mpmc.svg
@@ -4,19 +4,19 @@
 MPMC blocking wake latency (lower is better)
 </text>
 <text x="512" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 1; 10000 rounds; 50 us sleep settle
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 1; 10000 rounds; 50 µs sleep settle
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,225 1000,225 "/>
 <text x="62" y="225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-5 us
+5 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,153 1000,153 "/>
 <text x="62" y="153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-10 us
+10 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,82 1000,82 "/>
 <text x="62" y="82" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-15 us
+15 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,296 1000,296 "/>
 <rect x="110" y="169" width="36" height="127" opacity="1" fill="#F87171" stroke="none"/>

--- a/doc/charts/latency-mpsc.svg
+++ b/doc/charts/latency-mpsc.svg
@@ -4,19 +4,19 @@
 MPSC blocking wake latency (lower is better)
 </text>
 <text x="512" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 1; 10000 rounds; 50 us sleep settle
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 1; 10000 rounds; 50 µs sleep settle
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,225 1000,225 "/>
 <text x="62" y="225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-5 us
+5 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,153 1000,153 "/>
 <text x="62" y="153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-10 us
+10 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,82 1000,82 "/>
 <text x="62" y="82" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
-15 us
+15 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,296 1000,296 "/>
 <rect x="105" y="170" width="30" height="126" opacity="1" fill="#F87171" stroke="none"/>

--- a/src/bin/chart/latency.rs
+++ b/src/bin/chart/latency.rs
@@ -501,7 +501,7 @@ fn format_duration(ns: f64) -> String {
     if ns >= 1_000_000.0 {
         format!("{:.0} ms", ns / 1_000_000.0)
     } else if ns >= 1_000.0 {
-        format!("{:.0} us", ns / 1_000.0)
+        format!("{:.0} µs", ns / 1_000.0)
     } else {
         format!("{ns:.0} ns")
     }


### PR DESCRIPTION
- List nonblocking, blocking, timeout, and deadline operations in the README
- Clarify that readiness groups scale beyond 4,096 sender lanes
- Render latency chart values with the standard `µs` unit
- Regenerate both tracked wake-latency charts