### PR TITLE
Add Crossfire benchmark charts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossfire"
+version = "3.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111ce8f7abfbac38b4bc4f32a3a2dda1a8034b873c90c7899f302cc9dbbc05ec"
+dependencies = [
+ "crossbeam-utils",
+ "futures-core",
+ "parking_lot",
+ "pointers",
+ "smallvec",
+]
+
+[[package]]
 name = "fanring"
 version = "0.3.0"
 dependencies = [
@@ -98,6 +111,7 @@ dependencies = [
  "concurrent-queue",
  "core_affinity",
  "crossbeam-channel",
+ "crossfire",
  "flume",
  "kanal",
  "loom",
@@ -391,6 +405,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "pointers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcdc93847ad24990939cce6e1804361e903efcb5f99daa5abd87943a9d6d7ba"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ loom = "0.7"
 [dev-dependencies]
 core_affinity = "0.8.3"
 crossbeam-channel = "0.5"
+crossfire = "3.1.19"
 flume = "0.12"
 kanal = "0.1"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,6 +78,7 @@ cargo bench --bench wake_latency
 The benchmark compares `fanring` against:
 
 - `crossbeam-channel`
+- `crossfire`
 - `flume`
 - `kanal`
 - `concurrent-queue`
@@ -102,8 +103,8 @@ not support this profile because blocking sends do not expose full events.
 
 Implementations rotate order between samples. Shutdown and queue draining are
 included in elapsed time. Every run asserts that sent and received counts
-match. Output includes every sample and is appended to
-`target/fanring-bench/results.jsonl` or `target/fanring-bench/mpmc.jsonl`.
+match. Every sample is appended to
+`~/.cache/fanring/<implementation>/throughput-{mpsc,mpmc}.jsonl`.
 
 JSONL rows record `nominal_capacity`, `capacity_model`, `affinity`,
 `throughput_profile`, `low_watermark`, and `high_watermark`. Fanring uses a per-ring HWM. MPMC
@@ -115,15 +116,18 @@ Comparison benches accept `FANRING_BENCH_MODE`, `FANRING_BENCH_SECS`,
 `FANRING_BENCH_PRODUCERS`, `FANRING_BENCH_CAPACITY`,
 `FANRING_BENCH_PAYLOADS`, `FANRING_BENCH_IMPLS`, `FANRING_BENCH_SAMPLES`,
 `FANRING_BENCH_WARMUP_SECS`, `FANRING_BENCH_PROFILE`, and
-`FANRING_BENCH_AFFINITY` (`auto` or `off`), and `FANRING_BENCH_OUT`. MPMC also
-accepts `FANRING_BENCH_CONSUMERS`. `auto` is the default and records the exact
-logical CPU order in each row. Use `taskset` to restrict the available CPUs.
+`FANRING_BENCH_AFFINITY` (`auto` or `off`). MPMC also accepts
+`FANRING_BENCH_CONSUMERS`. `auto` is the default and records the exact logical
+CPU order in each row. Use `taskset` to restrict the available CPUs.
 
 Wake latency accepts `FANRING_WAKE_ROUNDS`, `FANRING_WAKE_WARMUP`,
-`FANRING_WAKE_SETTLE_NS`, `FANRING_WAKE_SETTLE_MODE` (`sleep` or `spin`), and
-`FANRING_WAKE_OUT`. It measures both a blocked receiver woken by a send and a
-blocked sender woken by a receive on capacity-one channels. All benchmarks
-append machine-readable JSONL.
+`FANRING_WAKE_SETTLE_NS`, and `FANRING_WAKE_SETTLE_MODE` (`sleep` or `spin`). It
+measures both a blocked receiver woken by a send and a blocked sender woken by
+a receive on capacity-one channels. Results are appended to
+`~/.cache/fanring/<implementation>/latency-{mpsc,mpmc}.jsonl`.
+
+`FANRING_BENCH_CACHE_DIR` overrides the `~/.cache/fanring` result root for every
+benchmark and the chart generator. Result files are append-only.
 
 Short smoke run:
 
@@ -140,7 +144,6 @@ Focused run:
 FANRING_BENCH_PAYLOADS=bytes64 \
 FANRING_BENCH_PRODUCERS=8 \
 FANRING_BENCH_IMPLS=fanring,crossbeam-channel \
-FANRING_BENCH_OUT=target/fanring-bench/focused.jsonl \
 cargo bench --bench comparison
 ```
 
@@ -160,9 +163,16 @@ cargo run --example fanring-chart
 
 Default output: `doc/charts/throughput-mpsc.svg`.
 
-The chart tool selects the latest complete nonblocking run, aggregates samples
-by median, and shows relative median absolute deviation below each throughput
-value. An explicit run ID may select a blocking run.
+The chart tool reads every implementation's append-only result file. It merges
+the latest compatible complete per-implementation runs, aggregates samples by
+median, and shows relative median absolute deviation below each throughput
+value. An explicit run ID selects one complete run and may select blocking data.
+
+Generate the MPMC detail chart:
+
+```sh
+cargo run --example fanring-chart -- --mpmc
+```
 
 Generate the two-topology summary chart from the latest complete nonblocking
 MPSC and MPMC runs:
@@ -193,26 +203,21 @@ postfix=6 physical cores / 12 threads, performance governor, turbo off
 `FANRING_HW_LABEL` overrides the complete label. `FANRING_HW_PREFIX` and
 `FANRING_HW_POSTFIX` override the corresponding file values.
 
-Custom paths:
+Use a different result root:
 
 ```sh
 cargo run --example fanring-chart -- \
-  --input target/fanring-bench/results.jsonl \
-  --output doc/charts/throughput-mpsc.svg
-
-cargo run --example fanring-chart -- \
-  --input target/fanring-bench/mpmc.jsonl \
-  --output doc/charts/throughput-mpmc.svg
+  --results-dir /path/to/fanring-results \
+  --output /path/to/throughput-mpsc.svg
 
 cargo run --example fanring-chart -- \
   --summary \
-  --mpsc-input target/fanring-bench/results.jsonl \
-  --mpmc-input target/fanring-bench/mpmc.jsonl \
-  --output doc/charts/throughput-summary.svg
+  --results-dir /path/to/fanring-results \
+  --output /path/to/throughput-summary.svg
 
 cargo run --example fanring-chart -- \
   --latency mpsc \
-  --input target/fanring-bench/wake-latency.jsonl \
+  --results-dir /path/to/fanring-results \
   --run RUN_ID \
-  --output doc/charts/latency-mpsc.svg
+  --output /path/to/latency-mpsc.svg
 ```

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -119,6 +119,7 @@ fn main() {}
 
 #[cfg(not(all(test, debug_assertions)))]
 fn main() {
+    crossfire::detect_backoff_cfg();
     let duration = Duration::from_secs_f64(
         std::env::var("FANRING_BENCH_SECS")
             .ok()
@@ -249,6 +250,9 @@ fn run_payload<T>(
     if impl_filter.matches("crossbeam-channel") {
         implementations.push(("crossbeam-channel", bench_crossbeam_channel::<T>));
     }
+    if impl_filter.matches("crossfire") {
+        implementations.push(("crossfire", bench_crossfire::<T>));
+    }
     if impl_filter.matches("flume") {
         implementations.push(("flume", bench_flume::<T>));
     }
@@ -353,6 +357,16 @@ where
         senders,
         rx,
     )
+}
+
+fn bench_crossfire<T>(context: &RunContext, config: Config, mode: Mode, payload: Payload<T>) -> Row
+where
+    T: Copy + Send + 'static,
+{
+    let (tx, rx) = crossfire::mpsc::bounded_blocking(config.total_capacity());
+    let senders = clones(&tx, config.producers);
+    drop(tx);
+    run_channel(context, "crossfire", config, mode, payload, senders, rx)
 }
 
 fn bench_flume<T>(context: &RunContext, config: Config, mode: Mode, payload: Payload<T>) -> Row
@@ -725,6 +739,38 @@ impl<T> BenchReceiver<T> for crossbeam_channel::Receiver<T> {
     }
 }
 
+impl<T: Send + 'static> BenchSender<T> for crossfire::MTx<crossfire::mpsc::Array<T>> {
+    #[inline(always)]
+    fn try_send(&mut self, value: T) -> SendAttempt {
+        match crossfire::BlockingTxTrait::try_send(self, value) {
+            Ok(()) => SendAttempt::Sent,
+            Err(crossfire::TrySendError::Full(_)) => SendAttempt::Full,
+            Err(crossfire::TrySendError::Disconnected(_)) => SendAttempt::Disconnected,
+        }
+    }
+
+    #[inline(always)]
+    fn send(&mut self, value: T) -> bool {
+        crossfire::BlockingTxTrait::send(self, value).is_ok()
+    }
+}
+
+impl<T: Send + 'static> BenchReceiver<T> for crossfire::Rx<crossfire::mpsc::Array<T>> {
+    #[inline(always)]
+    fn try_recv(&mut self) -> RecvAttempt<T> {
+        match crossfire::BlockingRxTrait::try_recv(self) {
+            Ok(value) => RecvAttempt::Item(value),
+            Err(crossfire::TryRecvError::Empty) => RecvAttempt::Empty,
+            Err(crossfire::TryRecvError::Disconnected) => RecvAttempt::Disconnected,
+        }
+    }
+
+    #[inline(always)]
+    fn recv(&mut self) -> Option<T> {
+        crossfire::BlockingRxTrait::recv(self).ok()
+    }
+}
+
 impl<T: Send + 'static> BenchSender<T> for flume::Sender<T> {
     #[inline(always)]
     fn try_send(&mut self, value: T) -> SendAttempt {
@@ -999,6 +1045,7 @@ fn selected_implementation_count(filter: &Filter, mode: Mode) -> usize {
     [
         ("fanring", true),
         ("crossbeam-channel", true),
+        ("crossfire", true),
         ("flume", true),
         ("kanal", true),
         ("concurrent-queue", mode == Mode::Try),

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -2,10 +2,7 @@
 
 mod support;
 
-use std::fs;
 use std::hint::black_box;
-use std::io::Write;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -13,7 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
-use support::{Affinity, Sampling, Saturation, append_jsonl, median_and_relative_mad};
+use support::{Affinity, JsonlResults, Sampling, Saturation, median_and_relative_mad};
 
 #[derive(Debug, Clone, Copy)]
 struct Config {
@@ -127,9 +124,7 @@ fn main() {
             .unwrap_or(1.0),
     );
     let sampling = Sampling::from_env();
-    let out_path = std::env::var_os("FANRING_BENCH_OUT")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("target/fanring-bench/results.jsonl"));
+    let mut results = JsonlResults::new("throughput-mpsc.jsonl");
     let payload_filter = Filter::from_env("FANRING_BENCH_PAYLOADS");
     let impl_filter = Filter::from_env("FANRING_BENCH_IMPLS");
     let mode = Mode::from_env();
@@ -148,13 +143,8 @@ fn main() {
         affinity: Affinity::from_env(),
     };
 
-    if let Some(parent) = out_path.parent() {
-        fs::create_dir_all(parent).expect("create benchmark output dir");
-    }
-    let mut out = append_jsonl(&out_path);
-
     println!(
-        "MPSC {} comparison ({}, {} x {:.2}s, {:.2}s warmup, capacity {} items, affinity {}, output {})\n",
+        "MPSC {} comparison ({}, {} x {:.2}s, {:.2}s warmup, capacity {} items, affinity {}, results {})\n",
         profile.label(),
         mode.label(),
         sampling.samples,
@@ -162,7 +152,7 @@ fn main() {
         sampling.warmup.as_secs_f64(),
         total_capacity(),
         context.affinity.description(),
-        out_path.display()
+        results.root().display()
     );
 
     let total_capacity = total_capacity();
@@ -187,7 +177,7 @@ fn main() {
     if payload_filter.matches("u64") {
         run_payload(
             &context,
-            &mut out,
+            &mut results,
             &configs,
             &impl_filter,
             sampling,
@@ -201,7 +191,7 @@ fn main() {
     if payload_filter.matches("bytes64") {
         run_payload(
             &context,
-            &mut out,
+            &mut results,
             &configs,
             &impl_filter,
             sampling,
@@ -215,7 +205,7 @@ fn main() {
     if payload_filter.matches("bytes256") {
         run_payload(
             &context,
-            &mut out,
+            &mut results,
             &configs,
             &impl_filter,
             sampling,
@@ -227,12 +217,12 @@ fn main() {
         );
     }
 
-    out.flush().expect("flush benchmark JSONL");
+    results.flush();
 }
 
 fn run_payload<T>(
     context: &RunContext,
-    out: &mut impl Write,
+    results: &mut JsonlResults,
     configs: &[Config],
     impl_filter: &Filter,
     sampling: Sampling,
@@ -300,8 +290,7 @@ fn run_payload<T>(
                     row.implementation,
                     row.items_per_sec / 1_000_000.0
                 );
-                serde_json::to_writer(&mut *out, &row).expect("write benchmark row");
-                writeln!(out).expect("write benchmark newline");
+                results.write(row.implementation, &row);
                 rows.push(row);
             }
         }

--- a/benches/mpmc.rs
+++ b/benches/mpmc.rs
@@ -2,10 +2,7 @@
 
 mod support;
 
-use std::fs;
 use std::hint::black_box;
-use std::io::Write;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -13,7 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
-use support::{Affinity, Sampling, Saturation, append_jsonl, median_and_relative_mad};
+use support::{Affinity, JsonlResults, Sampling, Saturation, median_and_relative_mad};
 
 #[derive(Debug, Clone, Copy)]
 struct Config {
@@ -123,9 +120,7 @@ fn main() {
     );
     let sampling = Sampling::from_env();
     let total_capacity = total_capacity();
-    let out_path = std::env::var_os("FANRING_BENCH_OUT")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("target/fanring-bench/mpmc.jsonl"));
+    let mut results = JsonlResults::new("throughput-mpmc.jsonl");
     let payload_filter = Filter::from_env("FANRING_BENCH_PAYLOADS");
     let impl_filter = Filter::from_env("FANRING_BENCH_IMPLS");
     let mode = Mode::from_env();
@@ -144,13 +139,8 @@ fn main() {
         affinity: Affinity::from_env(),
     };
 
-    if let Some(parent) = out_path.parent() {
-        fs::create_dir_all(parent).expect("create benchmark output dir");
-    }
-    let mut out = append_jsonl(&out_path);
-
     println!(
-        "MPMC {} comparison ({}, {} x {:.2}s, {:.2}s warmup, capacity {}, affinity {}, output {})\n",
+        "MPMC {} comparison ({}, {} x {:.2}s, {:.2}s warmup, capacity {}, affinity {}, results {})\n",
         profile.label(),
         mode.label(),
         sampling.samples,
@@ -158,7 +148,7 @@ fn main() {
         sampling.warmup.as_secs_f64(),
         total_capacity,
         context.affinity.description(),
-        out_path.display()
+        results.root().display()
     );
 
     let producer_counts = producer_counts();
@@ -190,7 +180,7 @@ fn main() {
     if payload_filter.matches("u64") {
         run_payload(
             &context,
-            &mut out,
+            &mut results,
             &configs,
             &impl_filter,
             sampling,
@@ -204,7 +194,7 @@ fn main() {
     if payload_filter.matches("bytes64") {
         run_payload(
             &context,
-            &mut out,
+            &mut results,
             &configs,
             &impl_filter,
             sampling,
@@ -218,7 +208,7 @@ fn main() {
     if payload_filter.matches("bytes256") {
         run_payload(
             &context,
-            &mut out,
+            &mut results,
             &configs,
             &impl_filter,
             sampling,
@@ -230,12 +220,12 @@ fn main() {
         );
     }
 
-    out.flush().expect("flush benchmark JSONL");
+    results.flush();
 }
 
 fn run_payload<T>(
     context: &RunContext,
-    out: &mut impl Write,
+    results: &mut JsonlResults,
     configs: &[Config],
     impl_filter: &Filter,
     sampling: Sampling,
@@ -295,8 +285,7 @@ fn run_payload<T>(
                     row.implementation,
                     row.items_per_sec / 1_000_000.0
                 );
-                serde_json::to_writer(&mut *out, &row).expect("write benchmark row");
-                writeln!(out).expect("write benchmark newline");
+                results.write(row.implementation, &row);
                 rows.push(row);
             }
         }

--- a/benches/mpmc.rs
+++ b/benches/mpmc.rs
@@ -114,6 +114,7 @@ fn main() {}
 
 #[cfg(not(all(test, debug_assertions)))]
 fn main() {
+    crossfire::detect_backoff_cfg();
     let duration = Duration::from_secs_f64(
         std::env::var("FANRING_BENCH_SECS")
             .ok()
@@ -252,6 +253,9 @@ fn run_payload<T>(
     if impl_filter.matches("crossbeam-channel") {
         implementations.push(("crossbeam-channel", bench_crossbeam::<T>));
     }
+    if impl_filter.matches("crossfire-mpmc") {
+        implementations.push(("crossfire-mpmc", bench_crossfire::<T>));
+    }
     if impl_filter.matches("flume") {
         implementations.push(("flume", bench_flume::<T>));
     }
@@ -350,6 +354,26 @@ where
     run_channel(
         context,
         "crossbeam-channel",
+        config,
+        mode,
+        payload,
+        senders,
+        receivers,
+    )
+}
+
+fn bench_crossfire<T>(context: &RunContext, config: Config, mode: Mode, payload: Payload<T>) -> Row
+where
+    T: Copy + Send + 'static,
+{
+    let (tx, rx) = crossfire::mpmc::bounded_blocking(config.total_capacity());
+    let senders = clones(&tx, config.producers);
+    let receivers = clones(&rx, config.consumers);
+    drop(tx);
+    drop(rx);
+    run_channel(
+        context,
+        "crossfire-mpmc",
         config,
         mode,
         payload,
@@ -773,6 +797,44 @@ where
     }
 }
 
+impl<T> BenchSender<T> for crossfire::MTx<crossfire::mpmc::Array<T>>
+where
+    T: Send + 'static,
+{
+    #[inline(always)]
+    fn try_send(&mut self, value: T) -> SendAttempt {
+        match crossfire::BlockingTxTrait::try_send(self, value) {
+            Ok(()) => SendAttempt::Sent,
+            Err(crossfire::TrySendError::Full(_)) => SendAttempt::Full,
+            Err(crossfire::TrySendError::Disconnected(_)) => SendAttempt::Disconnected,
+        }
+    }
+
+    #[inline(always)]
+    fn send(&mut self, value: T) -> bool {
+        crossfire::BlockingTxTrait::send(self, value).is_ok()
+    }
+}
+
+impl<T> BenchReceiver<T> for crossfire::MRx<crossfire::mpmc::Array<T>>
+where
+    T: Send + 'static,
+{
+    #[inline(always)]
+    fn try_recv(&mut self) -> RecvAttempt<T> {
+        match crossfire::BlockingRxTrait::try_recv(self) {
+            Ok(value) => RecvAttempt::Item(value),
+            Err(crossfire::TryRecvError::Empty) => RecvAttempt::Empty,
+            Err(crossfire::TryRecvError::Disconnected) => RecvAttempt::Disconnected,
+        }
+    }
+
+    #[inline(always)]
+    fn recv(&mut self) -> Option<T> {
+        crossfire::BlockingRxTrait::recv(self).ok()
+    }
+}
+
 impl<T> BenchSender<T> for flume::Sender<T>
 where
     T: Send + 'static,
@@ -931,10 +993,16 @@ fn selected_payload_count(filter: &Filter) -> usize {
 }
 
 fn selected_implementation_count(filter: &Filter) -> usize {
-    ["fanring-mpmc", "crossbeam-channel", "flume", "kanal"]
-        .into_iter()
-        .filter(|implementation| filter.matches(implementation))
-        .count()
+    [
+        "fanring-mpmc",
+        "crossbeam-channel",
+        "crossfire-mpmc",
+        "flume",
+        "kanal",
+    ]
+    .into_iter()
+    .filter(|implementation| filter.matches(implementation))
+    .count()
 }
 
 fn counts_from_env(name: &str, default: &[usize]) -> Vec<usize> {

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,15 +1,23 @@
 use std::collections::BTreeMap;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::Duration;
 
+use serde::Serialize;
+
 const LOW_WATERMARK_PERCENT: usize = 50;
 const HIGH_WATERMARK_PERCENT: usize = 100;
 const SPINS_BEFORE_YIELD: usize = 64;
+
+pub(crate) struct JsonlResults {
+    root: PathBuf,
+    file_name: &'static str,
+    writers: BTreeMap<String, BufWriter<File>>,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Sampling {
@@ -42,6 +50,65 @@ pub(crate) struct FullSignal {
     full_generation: Counters,
     index: usize,
     acknowledged: u64,
+}
+
+impl JsonlResults {
+    pub(crate) fn new(file_name: &'static str) -> Self {
+        Self {
+            root: results_root(),
+            file_name,
+            writers: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn write<T: Serialize>(&mut self, implementation: &str, row: &T) {
+        let directory = implementation_directory(implementation);
+        let path = result_path(&self.root, implementation, self.file_name);
+        let writer = self
+            .writers
+            .entry(directory.to_string())
+            .or_insert_with(|| {
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).expect("create benchmark result directory");
+                }
+                append_jsonl(&path)
+            });
+        serde_json::to_writer(&mut *writer, row).expect("write benchmark row");
+        writeln!(writer).expect("write benchmark newline");
+    }
+
+    pub(crate) fn flush(&mut self) {
+        for writer in self.writers.values_mut() {
+            writer.flush().expect("flush benchmark JSONL");
+        }
+    }
+}
+
+fn implementation_directory(implementation: &str) -> &str {
+    implementation
+        .strip_suffix("-mpmc")
+        .unwrap_or(implementation)
+}
+
+fn result_path(root: &Path, implementation: &str, file_name: &str) -> PathBuf {
+    root.join(implementation_directory(implementation))
+        .join(file_name)
+}
+
+fn results_root() -> PathBuf {
+    std::env::var_os("FANRING_BENCH_CACHE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(
+                std::env::var_os("HOME")
+                    .expect("HOME must be set unless FANRING_BENCH_CACHE_DIR is set"),
+            )
+            .join(".cache/fanring")
+        })
 }
 
 impl Saturation {
@@ -236,7 +303,7 @@ impl Sampling {
     }
 }
 
-pub(crate) fn append_jsonl(path: &Path) -> BufWriter<File> {
+fn append_jsonl(path: &Path) -> BufWriter<File> {
     let mut file = OpenOptions::new()
         .create(true)
         .read(true)
@@ -309,8 +376,10 @@ fn env_f64(name: &str, default: f64) -> f64 {
 }
 
 #[cfg(test)]
-mod affinity_tests {
-    use super::sibling_major;
+mod tests {
+    use std::path::Path;
+
+    use super::{result_path, sibling_major};
     use core_affinity::CoreId;
 
     fn six_smt_cores() -> Vec<Vec<CoreId>> {
@@ -327,5 +396,17 @@ mod affinity_tests {
             .collect::<Vec<_>>();
 
         assert_eq!(ids, (0..12).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn result_path_uses_topology_file_in_implementation_directory() {
+        assert_eq!(
+            result_path(
+                Path::new("/cache/fanring"),
+                "crossfire-mpmc",
+                "throughput-mpmc.jsonl"
+            ),
+            Path::new("/cache/fanring/crossfire/throughput-mpmc.jsonl")
+        );
     }
 }

--- a/benches/wake_latency.rs
+++ b/benches/wake_latency.rs
@@ -71,6 +71,30 @@ impl BlockingReceiver for crossbeam_channel::Receiver<u64> {
     }
 }
 
+impl BlockingSender for crossfire::MTx<crossfire::mpsc::Array<u64>> {
+    fn send(&mut self, value: u64) -> bool {
+        crossfire::BlockingTxTrait::send(self, value).is_ok()
+    }
+}
+
+impl BlockingReceiver for crossfire::Rx<crossfire::mpsc::Array<u64>> {
+    fn recv(&mut self) -> Option<u64> {
+        crossfire::BlockingRxTrait::recv(self).ok()
+    }
+}
+
+impl BlockingSender for crossfire::MTx<crossfire::mpmc::Array<u64>> {
+    fn send(&mut self, value: u64) -> bool {
+        crossfire::BlockingTxTrait::send(self, value).is_ok()
+    }
+}
+
+impl BlockingReceiver for crossfire::MRx<crossfire::mpmc::Array<u64>> {
+    fn recv(&mut self) -> Option<u64> {
+        crossfire::BlockingRxTrait::recv(self).ok()
+    }
+}
+
 impl BlockingSender for flume::Sender<u64> {
     fn send(&mut self, value: u64) -> bool {
         flume::Sender::send(self, value).is_ok()
@@ -112,6 +136,7 @@ fn main() {}
 
 #[cfg(not(all(test, debug_assertions)))]
 fn main() {
+    crossfire::detect_backoff_cfg();
     let rounds = env_usize("FANRING_WAKE_ROUNDS", 10_000);
     let warmup = env_usize("FANRING_WAKE_WARMUP", 200);
     let settle = Duration::from_nanos(env_u64("FANRING_WAKE_SETTLE_NS", 50_000));
@@ -183,6 +208,32 @@ fn main() {
             settle_mode,
             &mut out,
             || crossbeam_channel::bounded(1),
+        );
+    }
+    if filter.matches("crossfire") {
+        run_implementation(
+            &run_id,
+            &cpu,
+            "crossfire",
+            rounds,
+            warmup,
+            settle,
+            settle_mode,
+            &mut out,
+            || crossfire::mpsc::bounded_blocking(1),
+        );
+    }
+    if filter.matches("crossfire-mpmc") {
+        run_implementation(
+            &run_id,
+            &cpu,
+            "crossfire-mpmc",
+            rounds,
+            warmup,
+            settle,
+            settle_mode,
+            &mut out,
+            || crossfire::mpmc::bounded_blocking(1),
         );
     }
     if filter.matches("flume") {

--- a/benches/wake_latency.rs
+++ b/benches/wake_latency.rs
@@ -1,13 +1,14 @@
 #![cfg_attr(test, allow(dead_code, unused_imports))]
 
-use std::fs::{self, OpenOptions};
-use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+mod support;
+
 use std::sync::mpsc::sync_channel;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
+
+use support::JsonlResults;
 
 #[derive(Debug, Serialize)]
 struct Row {
@@ -141,10 +142,8 @@ fn main() {
     let warmup = env_usize("FANRING_WAKE_WARMUP", 200);
     let settle = Duration::from_nanos(env_u64("FANRING_WAKE_SETTLE_NS", 50_000));
     let settle_mode = SettleMode::from_env();
-    let out_path = std::env::var_os("FANRING_WAKE_OUT").map_or_else(
-        || PathBuf::from("target/fanring-bench/wake-latency.jsonl"),
-        PathBuf::from,
-    );
+    let mut mpsc_results = JsonlResults::new("latency-mpsc.jsonl");
+    let mut mpmc_results = JsonlResults::new("latency-mpmc.jsonl");
     let filter = Filter::from_env("FANRING_BENCH_IMPLS");
     let run_id = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -154,21 +153,11 @@ fn main() {
     let cpu = cpu_name();
 
     assert!(rounds > 0, "wake rounds must be > 0");
-    if let Some(parent) = out_path.parent() {
-        fs::create_dir_all(parent).expect("create benchmark output dir");
-    }
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&out_path)
-        .expect("open wake benchmark JSONL");
-    let mut out = BufWriter::new(file);
-
     println!(
-        "Wake latency ({rounds} samples, {warmup} warmup, {} ns {} settle, output {})\n",
+        "Wake latency ({rounds} samples, {warmup} warmup, {} ns {} settle, results {})\n",
         settle.as_nanos(),
         settle_mode.label(),
-        out_path.display()
+        mpsc_results.root().display()
     );
 
     if filter.matches("fanring") {
@@ -180,7 +169,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpsc_results],
             || fanring::mpsc::channel(1),
         );
     }
@@ -193,7 +182,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpmc_results],
             || fanring::mpmc::channel(1),
         );
     }
@@ -206,7 +195,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpsc_results, &mut mpmc_results],
             || crossbeam_channel::bounded(1),
         );
     }
@@ -219,7 +208,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpsc_results],
             || crossfire::mpsc::bounded_blocking(1),
         );
     }
@@ -232,7 +221,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpmc_results],
             || crossfire::mpmc::bounded_blocking(1),
         );
     }
@@ -245,7 +234,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpsc_results, &mut mpmc_results],
             || flume::bounded(1),
         );
     }
@@ -258,7 +247,7 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpsc_results, &mut mpmc_results],
             || kanal::bounded(1),
         );
     }
@@ -271,12 +260,13 @@ fn main() {
             warmup,
             settle,
             settle_mode,
-            &mut out,
+            &mut [&mut mpsc_results],
             || thingbuf::mpsc::blocking::channel(1),
         );
     }
 
-    out.flush().expect("flush wake benchmark JSONL");
+    mpsc_results.flush();
+    mpmc_results.flush();
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -288,7 +278,7 @@ fn run_implementation<S, R, F>(
     warmup: usize,
     settle: Duration,
     settle_mode: SettleMode,
-    out: &mut impl Write,
+    outputs: &mut [&mut JsonlResults],
     make_channel: F,
 ) where
     S: BlockingSender + 'static,
@@ -298,7 +288,7 @@ fn run_implementation<S, R, F>(
     let (sender, receiver) = make_channel();
     let recv_samples = measure_recv_wake(sender, receiver, rounds, warmup, settle, settle_mode);
     write_row(
-        out,
+        outputs,
         &summarize(
             run_id,
             cpu,
@@ -313,7 +303,7 @@ fn run_implementation<S, R, F>(
     let (sender, receiver) = make_channel();
     let send_samples = measure_send_wake(sender, receiver, rounds, warmup, settle, settle_mode);
     write_row(
-        out,
+        outputs,
         &summarize(
             run_id,
             cpu,
@@ -458,9 +448,10 @@ fn percentile(samples: &[u64], permille: usize) -> u64 {
     samples[index]
 }
 
-fn write_row(out: &mut impl Write, row: &Row) {
-    serde_json::to_writer(&mut *out, row).expect("write wake benchmark row");
-    writeln!(out).expect("write wake benchmark newline");
+fn write_row(outputs: &mut [&mut JsonlResults], row: &Row) {
+    for output in outputs {
+        output.write(row.implementation, row);
+    }
 }
 
 fn elapsed_ns(clock: Instant) -> u64 {

--- a/doc/charts/latency-mpmc.svg
+++ b/doc/charts/latency-mpmc.svg
@@ -6,44 +6,48 @@ MPMC blocking wake latency (lower is better)
 <text x="512" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 1; 10000 rounds; 50 µs sleep settle
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,225 1000,225 "/>
-<text x="62" y="225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,227 1000,227 "/>
+<text x="62" y="227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 5 µs
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,153 1000,153 "/>
-<text x="62" y="153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,158 1000,158 "/>
+<text x="62" y="158" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 10 µs
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,82 1000,82 "/>
-<text x="62" y="82" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,90 1000,90 "/>
+<text x="62" y="90" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 15 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,296 1000,296 "/>
-<rect x="110" y="169" width="36" height="127" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="149" y="201" width="36" height="95" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="188" y="172" width="36" height="124" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="227" y="264" width="36" height="32" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="105" y="173" width="30" height="123" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="138" y="175" width="30" height="121" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="171" y="174" width="30" height="122" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="204" y="175" width="30" height="121" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="237" y="288" width="30" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="186" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p50
 </text>
-<rect x="342" y="135" width="36" height="161" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="381" y="149" width="36" height="147" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="420" y="141" width="36" height="155" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="459" y="243" width="36" height="53" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="338" y="151" width="30" height="145" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="371" y="139" width="30" height="157" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="404" y="136" width="30" height="160" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="437" y="135" width="30" height="161" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="470" y="279" width="30" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="419" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p99
 </text>
-<rect x="575" y="168" width="36" height="128" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="614" y="172" width="36" height="124" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="653" y="172" width="36" height="124" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="692" y="286" width="36" height="10" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="570" y="175" width="30" height="121" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="603" y="176" width="30" height="120" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="636" y="160" width="30" height="136" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="669" y="175" width="30" height="121" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="702" y="285" width="30" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="651" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p50
 </text>
-<rect x="807" y="127" width="36" height="169" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="846" y="93" width="36" height="203" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="885" y="114" width="36" height="182" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="924" y="278" width="36" height="18" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="803" y="145" width="30" height="151" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="836" y="93" width="30" height="203" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="869" y="130" width="30" height="166" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="902" y="142" width="30" height="154" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="935" y="279" width="30" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="884" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p99
 </text>
@@ -61,12 +65,16 @@ fanring
 <text x="400" y="376" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 crossbeam-channel 0.5.16
 </text>
-<rect x="682" y="370" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="682" y="370" width="12" height="12" opacity="1" fill="#22D3EE" stroke="none"/>
 <text x="700" y="376" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
+crossfire 3.1.19
+</text>
+<rect x="82" y="390" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<text x="100" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 flume 0.12.0
 </text>
-<rect x="82" y="390" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
-<text x="100" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
+<rect x="382" y="390" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="400" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 kanal 0.1.1*
 </text>
 <text x="512" y="425" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#7D8590">

--- a/doc/charts/latency-mpsc.svg
+++ b/doc/charts/latency-mpsc.svg
@@ -6,48 +6,52 @@ MPSC blocking wake latency (lower is better)
 <text x="512" y="40" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 1; 10000 rounds; 50 µs sleep settle
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,225 1000,225 "/>
-<text x="62" y="225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,227 1000,227 "/>
+<text x="62" y="227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 5 µs
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,153 1000,153 "/>
-<text x="62" y="153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,158 1000,158 "/>
+<text x="62" y="158" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 10 µs
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,82 1000,82 "/>
-<text x="62" y="82" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,90 1000,90 "/>
+<text x="62" y="90" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#7D8590">
 15 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,296 1000,296 "/>
-<rect x="105" y="170" width="30" height="126" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="138" y="201" width="30" height="95" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="171" y="173" width="30" height="123" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="204" y="172" width="30" height="124" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="237" y="264" width="30" height="32" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="71" y="175" width="36" height="121" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="110" y="175" width="36" height="121" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="149" y="175" width="36" height="121" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="188" y="177" width="36" height="119" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="227" y="175" width="36" height="121" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="266" y="288" width="36" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="186" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p50
 </text>
-<rect x="338" y="107" width="30" height="189" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="371" y="149" width="30" height="147" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="404" y="136" width="30" height="160" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="437" y="141" width="30" height="155" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="470" y="243" width="30" height="53" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="303" y="142" width="36" height="154" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="342" y="139" width="36" height="157" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="381" y="142" width="36" height="154" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="420" y="140" width="36" height="156" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="459" y="135" width="36" height="161" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="498" y="279" width="36" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="419" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p99
 </text>
-<rect x="570" y="173" width="30" height="123" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="603" y="172" width="30" height="124" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="636" y="155" width="30" height="141" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="669" y="172" width="30" height="124" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="702" y="286" width="30" height="10" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="536" y="179" width="36" height="117" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="575" y="176" width="36" height="120" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="614" y="161" width="36" height="135" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="653" y="161" width="36" height="135" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="692" y="175" width="36" height="121" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="731" y="285" width="36" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="651" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p50
 </text>
-<rect x="803" y="135" width="30" height="161" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="836" y="93" width="30" height="203" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="869" y="105" width="30" height="191" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="902" y="114" width="30" height="182" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="935" y="278" width="30" height="18" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="768" y="146" width="36" height="150" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="807" y="93" width="36" height="203" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="846" y="130" width="36" height="166" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="885" y="137" width="36" height="159" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="924" y="142" width="36" height="154" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="963" y="279" width="36" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="884" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p99
 </text>
@@ -65,16 +69,20 @@ fanring
 <text x="400" y="376" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 crossbeam-channel 0.5.16
 </text>
-<rect x="682" y="370" width="12" height="12" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="682" y="370" width="12" height="12" opacity="1" fill="#22D3EE" stroke="none"/>
 <text x="700" y="376" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
+crossfire 3.1.19
+</text>
+<rect x="82" y="390" width="12" height="12" opacity="1" fill="#A78BFA" stroke="none"/>
+<text x="100" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 thingbuf 0.1.6
 </text>
-<rect x="82" y="390" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<text x="100" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
+<rect x="382" y="390" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<text x="400" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 flume 0.12.0
 </text>
-<rect x="382" y="390" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
-<text x="400" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
+<rect x="682" y="390" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="700" y="396" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E6EDF3">
 kanal 0.1.1*
 </text>
 <text x="512" y="425" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#7D8590">

--- a/doc/charts/latency-mpsc.svg
+++ b/doc/charts/latency-mpsc.svg
@@ -19,39 +19,39 @@ Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; capacity 
 15 µs
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,296 1000,296 "/>
-<rect x="71" y="175" width="36" height="121" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="110" y="175" width="36" height="121" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="149" y="175" width="36" height="121" opacity="1" fill="#22D3EE" stroke="none"/>
-<rect x="188" y="177" width="36" height="119" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="227" y="175" width="36" height="121" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="266" y="288" width="36" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="82" y="175" width="32" height="121" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="117" y="175" width="33" height="121" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="153" y="175" width="32" height="121" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="188" y="177" width="32" height="119" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="223" y="175" width="32" height="121" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="258" y="288" width="33" height="8" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="186" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p50
 </text>
-<rect x="303" y="142" width="36" height="154" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="342" y="139" width="36" height="157" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="381" y="142" width="36" height="154" opacity="1" fill="#22D3EE" stroke="none"/>
-<rect x="420" y="140" width="36" height="156" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="459" y="135" width="36" height="161" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="498" y="279" width="36" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="315" y="142" width="32" height="154" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="350" y="139" width="32" height="157" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="385" y="142" width="32" height="154" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="420" y="140" width="33" height="156" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="456" y="135" width="32" height="161" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="491" y="279" width="32" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="419" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p99
 </text>
-<rect x="536" y="179" width="36" height="117" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="575" y="176" width="36" height="120" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="614" y="161" width="36" height="135" opacity="1" fill="#22D3EE" stroke="none"/>
-<rect x="653" y="161" width="36" height="135" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="692" y="175" width="36" height="121" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="731" y="285" width="36" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="547" y="179" width="32" height="117" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="582" y="176" width="33" height="120" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="618" y="161" width="32" height="135" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="653" y="161" width="32" height="135" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="688" y="175" width="32" height="121" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="723" y="285" width="33" height="11" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="651" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p50
 </text>
-<rect x="768" y="146" width="36" height="150" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="807" y="93" width="36" height="203" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="846" y="130" width="36" height="166" opacity="1" fill="#22D3EE" stroke="none"/>
-<rect x="885" y="137" width="36" height="159" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="924" y="142" width="36" height="154" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="963" y="279" width="36" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="780" y="146" width="32" height="150" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="815" y="93" width="32" height="203" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="850" y="130" width="32" height="166" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="885" y="137" width="33" height="159" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="921" y="142" width="32" height="154" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="956" y="279" width="32" height="17" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="884" y="336" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3" font-weight="bold">
 p99
 </text>

--- a/doc/charts/throughput-mpmc.svg
+++ b/doc/charts/throughput-mpmc.svg
@@ -90,7 +90,6 @@ fanring
 +/-0.1%
 </text>
 <rect x="261" y="149" width="71" height="25" opacity="1" fill="#355580" stroke="none"/>
-<rect x="261" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 59.6
 </text>
@@ -105,7 +104,7 @@ fanring
 <text x="371" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-6.1%
 </text>
-<rect x="411" y="149" width="71" height="25" opacity="1" fill="#273B5A" stroke="none"/>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
 <rect x="411" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 30.8
@@ -129,7 +128,7 @@ fanring
 <text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4D82C6" stroke="none"/>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4D83C6" stroke="none"/>
 <rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
 111.1
@@ -185,7 +184,7 @@ fanring
 <text x="1145" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#2A4163" stroke="none"/>
 <rect x="1185" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 37.5
@@ -325,233 +324,349 @@ crossbeam-channel 0.5.16
 +/-5.2%
 </text>
 <text x="28" y="219" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
+crossfire 3.1.19
 </text>
-<rect x="186" y="207" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<rect x="186" y="207" width="71" height="25" opacity="1" fill="#2C4568" stroke="none"/>
 <text x="221" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
+41.5
 </text>
 <text x="221" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-0.1%
 </text>
-<rect x="261" y="207" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<rect x="261" y="207" width="71" height="25" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="261" y="207" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.2
+68.4
 </text>
 <text x="296" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.2%
++/-1.1%
 </text>
-<rect x="336" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="336" y="207" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="371" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.8
+13.9
 </text>
 <text x="371" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-2.2%
 </text>
-<rect x="411" y="207" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
+<rect x="411" y="207" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
 <text x="446" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
+12.6
 </text>
 <text x="446" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.1%
 </text>
-<rect x="494" y="207" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="494" y="207" width="71" height="25" opacity="1" fill="#283E5E" stroke="none"/>
 <text x="529" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.4
+33.9
 </text>
 <text x="529" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-0.1%
 </text>
-<rect x="569" y="207" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<rect x="569" y="207" width="71" height="25" opacity="1" fill="#2B4466" stroke="none"/>
 <text x="604" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.1
+40.5
 </text>
 <text x="604" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
++/-0.3%
 </text>
-<rect x="644" y="207" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="644" y="207" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
 <text x="679" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.2
+17.2
 </text>
 <text x="679" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-0.2%
 </text>
-<rect x="719" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<rect x="719" y="207" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="754" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.4
+12.1
 </text>
 <text x="754" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.3%
++/-0.7%
 </text>
-<rect x="802" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="802" y="207" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
 <text x="837" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
+20.7
 </text>
 <text x="837" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.2%
 </text>
-<rect x="877" y="207" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
+<rect x="877" y="207" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
 <text x="912" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.1
+23.1
 </text>
 <text x="912" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
++/-0.2%
 </text>
-<rect x="952" y="207" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="952" y="207" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
 <text x="987" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.2
+37.1
 </text>
 <text x="987" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="1027" y="207" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
-<text x="1062" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.3
-</text>
-<text x="1062" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
-</text>
-<rect x="1110" y="207" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
-<text x="1145" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
-</text>
-<text x="1145" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
-</text>
-<rect x="1185" y="207" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
-<text x="1220" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
-</text>
-<text x="1220" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="1260" y="207" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
-<text x="1295" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.1
-</text>
-<text x="1295" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
-</text>
-<rect x="1335" y="207" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="1370" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.4
-</text>
-<text x="1370" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
-</text>
-<text x="28" y="248" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="236" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
-<text x="221" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-45.5
-</text>
-<text x="221" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.5%
 </text>
-<rect x="261" y="236" width="71" height="25" opacity="1" fill="#293F5E" stroke="none"/>
-<text x="296" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.4
+<rect x="1027" y="207" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="1062" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.1
 </text>
-<text x="296" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.1%
+<text x="1062" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.5%
 </text>
-<rect x="336" y="236" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
-<text x="371" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.6
+<rect x="1110" y="207" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<text x="1145" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.0
 </text>
-<text x="371" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
+<text x="1145" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
 </text>
-<rect x="411" y="236" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="446" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.2
+<rect x="1185" y="207" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="1220" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.3
 </text>
-<text x="446" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.6%
-</text>
-<rect x="494" y="236" width="71" height="25" opacity="1" fill="#293E5E" stroke="none"/>
-<text x="529" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.4
-</text>
-<text x="529" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="1220" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="569" y="236" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="1260" y="207" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="1295" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.9
+</text>
+<text x="1295" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="1335" y="207" width="71" height="25" opacity="1" fill="#21314B" stroke="none"/>
+<text x="1370" y="215" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.7
+</text>
+<text x="1370" y="226" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<text x="28" y="248" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="236" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<text x="221" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.5
+</text>
+<text x="221" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="261" y="236" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="296" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.2
+</text>
+<text x="296" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.2%
+</text>
+<rect x="336" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="371" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.8
+</text>
+<text x="371" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="411" y="236" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
+<text x="446" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.8
+</text>
+<text x="446" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="494" y="236" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="529" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.4
+</text>
+<text x="529" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="569" y="236" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
 <text x="604" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-37.3
+7.1
 </text>
 <text x="604" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.3%
++/-2.4%
 </text>
-<rect x="644" y="236" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<rect x="644" y="236" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
 <text x="679" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-27.5
+5.2
 </text>
 <text x="679" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-3.9%
 </text>
-<rect x="719" y="236" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<rect x="719" y="236" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="754" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.4
+2.4
 </text>
 <text x="754" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.3%
 </text>
-<rect x="802" y="236" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="802" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="837" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-20.8
+4.5
 </text>
 <text x="837" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.4%
++/-0.3%
 </text>
-<rect x="877" y="236" width="71" height="25" opacity="1" fill="#253854" stroke="none"/>
+<rect x="877" y="236" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
 <text x="912" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-27.0
+5.1
 </text>
 <text x="912" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.6%
 </text>
-<rect x="952" y="236" width="71" height="25" opacity="1" fill="#23334E" stroke="none"/>
+<rect x="952" y="236" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
 <text x="987" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.9
+5.2
 </text>
 <text x="987" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-0.4%
 </text>
-<rect x="1027" y="236" width="71" height="25" opacity="1" fill="#1F2E45" stroke="none"/>
+<rect x="1027" y="236" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
 <text x="1062" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.5
+3.3
 </text>
 <text x="1062" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
++/-0.2%
 </text>
-<rect x="1110" y="236" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<rect x="1110" y="236" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
 <text x="1145" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.1
+1.7
 </text>
 <text x="1145" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.6%
++/-0.2%
 </text>
-<rect x="1185" y="236" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="1185" y="236" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1220" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.4
+2.2
 </text>
 <text x="1220" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.3%
++/-1.4%
 </text>
-<rect x="1260" y="236" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<rect x="1260" y="236" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
 <text x="1295" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.7
+3.1
 </text>
 <text x="1295" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.3%
 </text>
-<rect x="1335" y="236" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<rect x="1335" y="236" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="1370" y="244" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-16.7
+4.4
 </text>
 <text x="1370" y="255" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<text x="28" y="277" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="265" width="71" height="25" opacity="1" fill="#2E486D" stroke="none"/>
+<text x="221" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+45.5
+</text>
+<text x="221" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="261" y="265" width="71" height="25" opacity="1" fill="#293F5E" stroke="none"/>
+<text x="296" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+34.4
+</text>
+<text x="296" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.1%
+</text>
+<rect x="336" y="265" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<text x="371" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+22.6
+</text>
+<text x="371" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.8%
+</text>
+<rect x="411" y="265" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="446" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.2
+</text>
+<text x="446" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-8.6%
+</text>
+<rect x="494" y="265" width="71" height="25" opacity="1" fill="#293F5E" stroke="none"/>
+<text x="529" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+34.4
+</text>
+<text x="529" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="569" y="265" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<text x="604" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+37.3
+</text>
+<text x="604" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.3%
+</text>
+<rect x="644" y="265" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
+<text x="679" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+27.5
+</text>
+<text x="679" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.2%
+</text>
+<rect x="719" y="265" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="754" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+13.4
+</text>
+<text x="754" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.3%
+</text>
+<rect x="802" y="265" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<text x="837" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+20.8
+</text>
+<text x="837" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-10.4%
+</text>
+<rect x="877" y="265" width="71" height="25" opacity="1" fill="#253854" stroke="none"/>
+<text x="912" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+27.0
+</text>
+<text x="912" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="952" y="265" width="71" height="25" opacity="1" fill="#23334D" stroke="none"/>
+<text x="987" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+21.9
+</text>
+<text x="987" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.2%
+</text>
+<rect x="1027" y="265" width="71" height="25" opacity="1" fill="#1F2E45" stroke="none"/>
+<text x="1062" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+15.5
+</text>
+<text x="1062" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.7%
+</text>
+<rect x="1110" y="265" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<text x="1145" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.1
+</text>
+<text x="1145" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.6%
+</text>
+<rect x="1185" y="265" width="71" height="25" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="1220" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.4
+</text>
+<text x="1220" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.3%
+</text>
+<rect x="1260" y="265" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="1295" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.7
+</text>
+<text x="1295" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="1335" y="265" width="71" height="25" opacity="1" fill="#202F46" stroke="none"/>
+<text x="1370" y="273" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+16.7
+</text>
+<text x="1370" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.1%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,293 1416,293 "/>
@@ -638,7 +753,6 @@ fanring
 +/-0.3%
 </text>
 <rect x="261" y="385" width="71" height="25" opacity="1" fill="#304C73" stroke="none"/>
-<rect x="261" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 33.1
 </text>
@@ -653,7 +767,7 @@ fanring
 <text x="371" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.5%
 </text>
-<rect x="411" y="385" width="71" height="25" opacity="1" fill="#2A4061" stroke="none"/>
+<rect x="411" y="385" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <rect x="411" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 24.3
@@ -662,7 +776,6 @@ fanring
 +/-9.0%
 </text>
 <rect x="494" y="385" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
-<rect x="494" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 24.6
 </text>
@@ -685,7 +798,7 @@ fanring
 <text x="679" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="719" y="385" width="71" height="25" opacity="1" fill="#426DA5" stroke="none"/>
+<rect x="719" y="385" width="71" height="25" opacity="1" fill="#426DA6" stroke="none"/>
 <rect x="719" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 58.2
@@ -701,7 +814,7 @@ fanring
 <text x="837" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="877" y="385" width="71" height="25" opacity="1" fill="#304C74" stroke="none"/>
+<rect x="877" y="385" width="71" height="25" opacity="1" fill="#304D74" stroke="none"/>
 <rect x="877" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 33.5
@@ -761,7 +874,6 @@ fanring
 crossbeam-channel 0.5.16
 </text>
 <rect x="186" y="414" width="71" height="25" opacity="1" fill="#375986" stroke="none"/>
-<rect x="186" y="414" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 42.5
 </text>
@@ -824,14 +936,14 @@ crossbeam-channel 0.5.16
 <text x="837" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.3%
 </text>
-<rect x="877" y="414" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<rect x="877" y="414" width="71" height="25" opacity="1" fill="#213049" stroke="none"/>
 <text x="912" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 12.4
 </text>
 <text x="912" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-10.7%
 </text>
-<rect x="952" y="414" width="71" height="25" opacity="1" fill="#23354F" stroke="none"/>
+<rect x="952" y="414" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
 <text x="987" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 15.4
 </text>
@@ -866,7 +978,7 @@ crossbeam-channel 0.5.16
 <text x="1295" y="433" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="1335" y="414" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<rect x="1335" y="414" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
 <text x="1370" y="422" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.4
 </text>
@@ -874,233 +986,351 @@ crossbeam-channel 0.5.16
 +/-4.1%
 </text>
 <text x="28" y="455" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
+crossfire 3.1.19
 </text>
-<rect x="186" y="443" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="186" y="443" width="71" height="25" opacity="1" fill="#406AA0" stroke="none"/>
+<rect x="186" y="443" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.5
+55.6
 </text>
 <text x="221" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="261" y="443" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
-<text x="296" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.1
-</text>
-<text x="296" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.0%
-</text>
-<rect x="336" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
-<text x="371" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.6
-</text>
-<text x="371" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-7.6%
-</text>
-<rect x="411" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
-<text x="446" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
-</text>
-<text x="446" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
-</text>
-<rect x="494" y="443" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
-<text x="529" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.2
-</text>
-<text x="529" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.7%
-</text>
-<rect x="569" y="443" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
-<text x="604" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.2
-</text>
-<text x="604" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.4%
-</text>
-<rect x="644" y="443" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
-<text x="679" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.2
-</text>
-<text x="679" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.5%
-</text>
-<rect x="719" y="443" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
-<text x="754" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
-</text>
-<text x="754" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
-</text>
-<rect x="802" y="443" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="837" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
-</text>
-<text x="837" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="877" y="443" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
-<text x="912" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.6
-</text>
-<text x="912" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
-</text>
-<rect x="952" y="443" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
-<text x="987" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
-</text>
-<text x="987" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.7%
-</text>
-<rect x="1027" y="443" width="71" height="25" opacity="1" fill="#1A2435" stroke="none"/>
-<text x="1062" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
-</text>
-<text x="1062" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="1110" y="443" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
-<text x="1145" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.1
-</text>
-<text x="1145" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
-</text>
-<rect x="1185" y="443" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
-<text x="1220" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.6
-</text>
-<text x="1220" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
-</text>
-<rect x="1260" y="443" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
-<text x="1295" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
-</text>
-<text x="1295" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.6%
-</text>
-<rect x="1335" y="443" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="1370" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
-</text>
-<text x="1370" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
-</text>
-<text x="28" y="484" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="472" width="71" height="25" opacity="1" fill="#23354F" stroke="none"/>
-<text x="221" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.5
-</text>
-<text x="221" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.4%
-</text>
-<rect x="261" y="472" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
-<text x="296" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.3
-</text>
-<text x="296" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.4%
-</text>
-<rect x="336" y="472" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
-<text x="371" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-15.8
-</text>
-<text x="371" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="411" y="472" width="71" height="25" opacity="1" fill="#1C283B" stroke="none"/>
+<rect x="261" y="443" width="71" height="25" opacity="1" fill="#365784" stroke="none"/>
+<rect x="261" y="443" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="296" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+41.4
+</text>
+<text x="296" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="336" y="443" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
+<text x="371" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+15.7
+</text>
+<text x="371" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.8%
+</text>
+<rect x="411" y="443" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="446" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.0
+</text>
+<text x="446" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="494" y="443" width="71" height="25" opacity="1" fill="#375A88" stroke="none"/>
+<rect x="494" y="443" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="529" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+43.6
+</text>
+<text x="529" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="569" y="443" width="71" height="25" opacity="1" fill="#2C4569" stroke="none"/>
+<text x="604" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+28.2
+</text>
+<text x="604" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="644" y="443" width="71" height="25" opacity="1" fill="#283D5C" stroke="none"/>
+<text x="679" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+21.6
+</text>
+<text x="679" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="719" y="443" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="754" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.6
+</text>
+<text x="754" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="802" y="443" width="71" height="25" opacity="1" fill="#1F2E45" stroke="none"/>
+<text x="837" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.3
+</text>
+<text x="837" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.7%
+</text>
+<rect x="877" y="443" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="912" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.5
+</text>
+<text x="912" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="952" y="443" width="71" height="25" opacity="1" fill="#202F47" stroke="none"/>
+<text x="987" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.3
+</text>
+<text x="987" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="1027" y="443" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="1062" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.9
+</text>
+<text x="1062" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="1110" y="443" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<text x="1145" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.3
+</text>
+<text x="1145" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="1185" y="443" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="1220" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.7
+</text>
+<text x="1220" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="1260" y="443" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="1295" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.4
+</text>
+<text x="1295" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<rect x="1335" y="443" width="71" height="25" opacity="1" fill="#1F2C43" stroke="none"/>
+<text x="1370" y="451" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.3
+</text>
+<text x="1370" y="462" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<text x="28" y="484" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<text x="221" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.5
+</text>
+<text x="221" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.4%
+</text>
+<rect x="261" y="472" width="71" height="25" opacity="1" fill="#1C273A" stroke="none"/>
+<text x="296" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.1
+</text>
+<text x="296" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.0%
+</text>
+<rect x="336" y="472" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="371" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.6
+</text>
+<text x="371" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-7.6%
+</text>
+<rect x="411" y="472" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="446" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.7
+1.4
 </text>
 <text x="446" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.6%
++/-1.1%
 </text>
-<rect x="494" y="472" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<rect x="494" y="472" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
 <text x="529" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.0
+4.2
 </text>
 <text x="529" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-3.7%
 </text>
-<rect x="569" y="472" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
+<rect x="569" y="472" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="604" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.2
+5.2
 </text>
 <text x="604" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-3.4%
 </text>
-<rect x="644" y="472" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<rect x="644" y="472" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
 <text x="679" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.6
+4.2
 </text>
 <text x="679" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
++/-5.5%
 </text>
-<rect x="719" y="472" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
+<rect x="719" y="472" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
 <text x="754" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.8
+2.0
 </text>
 <text x="754" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.8%
++/-1.6%
 </text>
-<rect x="802" y="472" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
+<rect x="802" y="472" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="837" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
+2.8
 </text>
 <text x="837" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.6%
++/-0.1%
 </text>
-<rect x="877" y="472" width="71" height="25" opacity="1" fill="#1D283D" stroke="none"/>
+<rect x="877" y="472" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="912" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.4
+3.6
 </text>
 <text x="912" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.2%
 </text>
-<rect x="952" y="472" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<rect x="952" y="472" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
 <text x="987" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.6
+3.4
 </text>
 <text x="987" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-2.7%
 </text>
-<rect x="1027" y="472" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<rect x="1027" y="472" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="1062" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.0
+2.6
 </text>
 <text x="1062" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
++/-1.4%
 </text>
-<rect x="1110" y="472" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
+<rect x="1110" y="472" width="71" height="25" opacity="1" fill="#192132" stroke="none"/>
 <text x="1145" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
+1.1
 </text>
 <text x="1145" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.1%
++/-2.2%
 </text>
-<rect x="1185" y="472" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<rect x="1185" y="472" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1220" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.1
+1.6
 </text>
 <text x="1220" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.2%
++/-1.1%
 </text>
-<rect x="1260" y="472" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="1260" y="472" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
 <text x="1295" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.6
+2.2
 </text>
 <text x="1295" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-2.6%
 </text>
-<rect x="1335" y="472" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="1335" y="472" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="1370" y="480" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.6
+3.2
 </text>
 <text x="1370" y="491" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
+</text>
+<text x="28" y="513" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="501" width="71" height="25" opacity="1" fill="#23354F" stroke="none"/>
+<text x="221" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+15.5
+</text>
+<text x="221" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.4%
+</text>
+<rect x="261" y="501" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
+<text x="296" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+15.3
+</text>
+<text x="296" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-8.4%
+</text>
+<rect x="336" y="501" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
+<text x="371" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+15.8
+</text>
+<text x="371" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="411" y="501" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="446" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.7
+</text>
+<text x="446" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.6%
+</text>
+<rect x="494" y="501" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="529" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.0
+</text>
+<text x="529" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="569" y="501" width="71" height="25" opacity="1" fill="#22324B" stroke="none"/>
+<text x="604" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+13.2
+</text>
+<text x="604" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="644" y="501" width="71" height="25" opacity="1" fill="#213149" stroke="none"/>
+<text x="679" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.6
+</text>
+<text x="679" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.9%
+</text>
+<rect x="719" y="501" width="71" height="25" opacity="1" fill="#1E2A40" stroke="none"/>
+<text x="754" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.8
+</text>
+<text x="754" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.8%
+</text>
+<rect x="802" y="501" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="837" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.2
+</text>
+<text x="837" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.6%
+</text>
+<rect x="877" y="501" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<text x="912" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.4
+</text>
+<text x="912" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.2%
+</text>
+<rect x="952" y="501" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="987" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.6
+</text>
+<text x="987" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="1027" y="501" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="1062" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.0
+</text>
+<text x="1062" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="1110" y="501" width="71" height="25" opacity="1" fill="#192334" stroke="none"/>
+<text x="1145" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.0
+</text>
+<text x="1145" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.1%
+</text>
+<rect x="1185" y="501" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
+<text x="1220" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.1
+</text>
+<text x="1220" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.2%
+</text>
+<rect x="1260" y="501" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="1295" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.6
+</text>
+<text x="1295" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="1335" y="501" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<text x="1370" y="509" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.6
+</text>
+<text x="1370" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.2%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,529 1416,529 "/>
@@ -1194,7 +1424,7 @@ fanring
 <text x="296" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="336" y="621" width="71" height="25" opacity="1" fill="#365884" stroke="none"/>
+<rect x="336" y="621" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
 <rect x="336" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 25.1
@@ -1202,7 +1432,7 @@ fanring
 <text x="371" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.5%
 </text>
-<rect x="411" y="621" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="411" y="621" width="71" height="25" opacity="1" fill="#2A4161" stroke="none"/>
 <rect x="411" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14.7
@@ -1249,7 +1479,7 @@ fanring
 <text x="837" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.3%
 </text>
-<rect x="877" y="621" width="71" height="25" opacity="1" fill="#33527C" stroke="none"/>
+<rect x="877" y="621" width="71" height="25" opacity="1" fill="#33527B" stroke="none"/>
 <rect x="877" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 22.4
@@ -1307,8 +1537,7 @@ fanring
 <text x="28" y="662" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="650" width="71" height="25" opacity="1" fill="#385B89" stroke="none"/>
-<rect x="186" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="186" y="650" width="71" height="25" opacity="1" fill="#385B8A" stroke="none"/>
 <text x="221" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 26.6
 </text>
@@ -1337,7 +1566,6 @@ crossbeam-channel 0.5.16
 +/-1.0%
 </text>
 <rect x="494" y="650" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
-<rect x="494" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14.9
 </text>
@@ -1394,7 +1622,6 @@ crossbeam-channel 0.5.16
 +/-0.1%
 </text>
 <rect x="1110" y="650" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
-<rect x="1110" y="650" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1145" y="658" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.9
 </text>
@@ -1423,233 +1650,351 @@ crossbeam-channel 0.5.16
 +/-3.7%
 </text>
 <text x="28" y="691" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
+crossfire 3.1.19
 </text>
-<rect x="186" y="679" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<rect x="186" y="679" width="71" height="25" opacity="1" fill="#3F689D" stroke="none"/>
+<rect x="186" y="679" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.6
+32.4
 </text>
 <text x="221" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.7%
 </text>
-<rect x="261" y="679" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<rect x="261" y="679" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
 <text x="296" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.5
+14.9
 </text>
 <text x="296" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
++/-7.2%
 </text>
-<rect x="336" y="679" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="336" y="679" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
 <text x="371" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
+9.4
 </text>
 <text x="371" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.2%
-</text>
-<rect x="411" y="679" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
-<text x="446" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.0
-</text>
-<text x="446" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<rect x="494" y="679" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
-<text x="529" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
-</text>
-<text x="529" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
-</text>
-<rect x="569" y="679" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
-<text x="604" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.7
-</text>
-<text x="604" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
-</text>
-<rect x="644" y="679" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="679" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.2
-</text>
-<text x="679" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
-</text>
-<rect x="719" y="679" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="754" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
-</text>
-<text x="754" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
-</text>
-<rect x="802" y="679" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
-<text x="837" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.1
-</text>
-<text x="837" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<rect x="877" y="679" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
-<text x="912" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.6
-</text>
-<text x="912" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.3%
 </text>
-<rect x="952" y="679" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
-<text x="987" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.5
+<rect x="411" y="679" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
+<text x="446" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.1
 </text>
-<text x="987" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.9%
+<text x="446" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
 </text>
-<rect x="1027" y="679" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
-<text x="1062" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.0
+<rect x="494" y="679" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<rect x="494" y="679" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="529" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+24.4
 </text>
-<text x="1062" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
+<text x="529" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
 </text>
-<rect x="1110" y="679" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
-<text x="1145" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.7
+<rect x="569" y="679" width="71" height="25" opacity="1" fill="#2F4A70" stroke="none"/>
+<text x="604" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.1
 </text>
-<text x="1145" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="604" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.1%
+</text>
+<rect x="644" y="679" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<text x="679" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.8
+</text>
+<text x="679" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="1185" y="679" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
-<text x="1220" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.0
+<rect x="719" y="679" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<text x="754" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.8
 </text>
-<text x="1220" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
+<text x="754" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
 </text>
-<rect x="1260" y="679" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
-<text x="1295" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.3
+<rect x="802" y="679" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
+<text x="837" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.1
 </text>
-<text x="1295" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
+<text x="837" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
 </text>
-<rect x="1335" y="679" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
-<text x="1370" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.8
-</text>
-<text x="1370" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.9%
-</text>
-<text x="28" y="720" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="708" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
-<text x="221" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.3
-</text>
-<text x="221" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-23.3%
-</text>
-<rect x="261" y="708" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
-<text x="296" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.2
-</text>
-<text x="296" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
-</text>
-<rect x="336" y="708" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
-<text x="371" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.6
-</text>
-<text x="371" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.6%
-</text>
-<rect x="411" y="708" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
-<text x="446" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.4
-</text>
-<text x="446" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.5%
-</text>
-<rect x="494" y="708" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="529" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.7
-</text>
-<text x="529" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.7%
-</text>
-<rect x="569" y="708" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
-<text x="604" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="877" y="679" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
+<text x="912" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.7
 </text>
-<text x="604" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.6%
+<text x="912" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
 </text>
-<rect x="644" y="708" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
+<rect x="952" y="679" width="71" height="25" opacity="1" fill="#243753" stroke="none"/>
+<text x="987" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.3
+</text>
+<text x="987" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="1027" y="679" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<text x="1062" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.0
+</text>
+<text x="1062" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="1110" y="679" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<rect x="1110" y="679" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1145" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.0
+</text>
+<text x="1145" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="1185" y="679" width="71" height="25" opacity="1" fill="#22334C" stroke="none"/>
+<text x="1220" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.4
+</text>
+<text x="1220" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="1260" y="679" width="71" height="25" opacity="1" fill="#22334C" stroke="none"/>
+<text x="1295" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.4
+</text>
+<text x="1295" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.7%
+</text>
+<rect x="1335" y="679" width="71" height="25" opacity="1" fill="#23344F" stroke="none"/>
+<text x="1370" y="687" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.2
+</text>
+<text x="1370" y="698" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<text x="28" y="720" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="708" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="221" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.6
+</text>
+<text x="221" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.7%
+</text>
+<rect x="261" y="708" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="296" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.5
+</text>
+<text x="296" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.5%
+</text>
+<rect x="336" y="708" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="371" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.8
+</text>
+<text x="371" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.2%
+</text>
+<rect x="411" y="708" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
+<text x="446" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.0
+</text>
+<text x="446" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="494" y="708" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<text x="529" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.9
+</text>
+<text x="529" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="569" y="708" width="71" height="25" opacity="1" fill="#1C283C" stroke="none"/>
+<text x="604" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.7
+</text>
+<text x="604" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="644" y="708" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="679" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.6
+3.2
 </text>
 <text x="679" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.3%
++/-2.0%
 </text>
-<rect x="719" y="708" width="71" height="25" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="719" y="708" width="71" height="25" opacity="1" fill="#1A2335" stroke="none"/>
 <text x="754" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.4
+1.4
 </text>
 <text x="754" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-2.2%
 </text>
 <rect x="802" y="708" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="837" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
+2.1
 </text>
 <text x="837" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.0%
++/-0.6%
 </text>
-<rect x="877" y="708" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<rect x="877" y="708" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="912" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.1
+2.6
 </text>
 <text x="912" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.2%
++/-0.3%
 </text>
-<rect x="952" y="708" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<rect x="952" y="708" width="71" height="25" opacity="1" fill="#1B2638" stroke="none"/>
 <text x="987" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.8
+2.5
 </text>
 <text x="987" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-1.9%
 </text>
-<rect x="1027" y="708" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<rect x="1027" y="708" width="71" height="25" opacity="1" fill="#1A2437" stroke="none"/>
 <text x="1062" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.2
+2.0
 </text>
 <text x="1062" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.0%
++/-1.0%
 </text>
-<rect x="1110" y="708" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
+<rect x="1110" y="708" width="71" height="25" opacity="1" fill="#192232" stroke="none"/>
 <text x="1145" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.3
+0.7
 </text>
 <text x="1145" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="1185" y="708" width="71" height="25" opacity="1" fill="#1A2537" stroke="none"/>
+<rect x="1185" y="708" width="71" height="25" opacity="1" fill="#192233" stroke="none"/>
 <text x="1220" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.1
+1.0
 </text>
 <text x="1220" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.2%
++/-0.7%
 </text>
-<rect x="1260" y="708" width="71" height="25" opacity="1" fill="#1B263A" stroke="none"/>
+<rect x="1260" y="708" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
 <text x="1295" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
+1.3
 </text>
 <text x="1295" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
++/-1.5%
 </text>
-<rect x="1335" y="708" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<rect x="1335" y="708" width="71" height="25" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="1370" y="716" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.0
+1.8
 </text>
 <text x="1370" y="727" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<text x="28" y="749" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="737" width="71" height="25" opacity="1" fill="#263956" stroke="none"/>
+<text x="221" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.3
+</text>
+<text x="221" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-23.3%
+</text>
+<rect x="261" y="737" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
+<text x="296" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.2
+</text>
+<text x="296" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.4%
+</text>
+<rect x="336" y="737" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
+<text x="371" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.6
+</text>
+<text x="371" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.6%
+</text>
+<rect x="411" y="737" width="71" height="25" opacity="1" fill="#1B2538" stroke="none"/>
+<text x="446" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.4
+</text>
+<text x="446" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.5%
+</text>
+<rect x="494" y="737" width="71" height="25" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="529" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.7
+</text>
+<text x="529" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.7%
+</text>
+<rect x="569" y="737" width="71" height="25" opacity="1" fill="#22334D" stroke="none"/>
+<text x="604" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.7
+</text>
+<text x="604" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.6%
+</text>
+<rect x="644" y="737" width="71" height="25" opacity="1" fill="#243550" stroke="none"/>
+<text x="679" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.6
+</text>
+<text x="679" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.3%
+</text>
+<rect x="719" y="737" width="71" height="25" opacity="1" fill="#1C283B" stroke="none"/>
+<text x="754" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.4
+</text>
+<text x="754" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="802" y="737" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="837" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.2
+</text>
+<text x="837" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-9.0%
+</text>
+<rect x="877" y="737" width="71" height="25" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="912" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.1
+</text>
+<text x="912" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.2%
+</text>
+<rect x="952" y="737" width="71" height="25" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="987" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.8
+</text>
+<text x="987" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="1027" y="737" width="71" height="25" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="1062" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.2
+</text>
+<text x="1062" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.0%
+</text>
+<rect x="1110" y="737" width="71" height="25" opacity="1" fill="#1A2334" stroke="none"/>
+<text x="1145" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.3
+</text>
+<text x="1145" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="1185" y="737" width="71" height="25" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="1220" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.1
+</text>
+<text x="1220" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.2%
+</text>
+<rect x="1260" y="737" width="71" height="25" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="1295" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.8
+</text>
+<text x="1295" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="1335" y="737" width="71" height="25" opacity="1" fill="#1D293D" stroke="none"/>
+<text x="1370" y="745" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.0
+</text>
+<text x="1370" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,765 1416,765 "/>

--- a/doc/charts/throughput-mpsc.svg
+++ b/doc/charts/throughput-mpsc.svg
@@ -1,5 +1,5 @@
-<svg width="1024" height="790" viewBox="0 0 1024 790" xmlns="http://www.w3.org/2000/svg">
-<rect x="0" y="0" width="1024" height="790" opacity="1" fill="#000000" stroke="none"/>
+<svg width="1024" height="865" viewBox="0 0 1024 865" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="1024" height="865" opacity="1" fill="#000000" stroke="none"/>
 <text x="512" y="17" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="12.096774193548388" opacity="1" fill="#E5E7EB">
 fanring MPSC throughput comparison
 </text>
@@ -39,7 +39,6 @@ fanring
 +/-0.5%
 </text>
 <rect x="390" y="128" width="200" height="21" opacity="1" fill="#548FD8" stroke="none"/>
-<rect x="390" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
 66.6
 </text>
@@ -55,7 +54,6 @@ fanring
 +/-1.5%
 </text>
 <rect x="798" y="128" width="200" height="21" opacity="1" fill="#345480" stroke="none"/>
-<rect x="798" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 31.5
 </text>
@@ -94,555 +92,650 @@ crossbeam-channel 0.5.16
 +/-0.9%
 </text>
 <text x="28" y="188" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-concurrent-queue 2.5.0
+crossfire 3.1.19
 </text>
-<rect x="186" y="178" width="200" height="21" opacity="1" fill="#2C4669" stroke="none"/>
-<text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.7
+<rect x="186" y="178" width="200" height="21" opacity="1" fill="#538DD5" stroke="none"/>
+<text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+65.4
 </text>
-<text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.5%
-</text>
-<rect x="390" y="178" width="200" height="21" opacity="1" fill="#23344F" stroke="none"/>
-<text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-12.3
-</text>
-<text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="594" y="178" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
-<text x="694" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.7
-</text>
-<text x="694" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="798" y="178" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="898" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
-</text>
-<text x="898" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
-</text>
-<rect x="186" y="203" width="200" height="21" opacity="1" fill="#2E486D" stroke="none"/>
-<text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.2
-</text>
-<text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.2%
 </text>
-<rect x="390" y="203" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
-<text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.6
+<rect x="390" y="178" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="390" y="178" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+66.8
 </text>
-<text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.4%
-</text>
-<rect x="594" y="203" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
-<text x="694" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.6
-</text>
-<text x="694" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="798" y="203" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
-<text x="898" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.9
-</text>
-<text x="898" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<text x="28" y="238" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="228" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
-<text x="286" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
-</text>
-<text x="286" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
-</text>
-<rect x="390" y="228" width="200" height="21" opacity="1" fill="#1E2A40" stroke="none"/>
-<text x="490" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.3
-</text>
-<text x="490" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.7%
 </text>
-<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="694" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.3
+<rect x="594" y="178" width="200" height="21" opacity="1" fill="#314E76" stroke="none"/>
+<text x="694" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+27.6
 </text>
-<text x="694" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
+<text x="694" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
 </text>
-<rect x="798" y="228" width="200" height="21" opacity="1" fill="#192334" stroke="none"/>
-<text x="898" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.7
+<rect x="798" y="178" width="200" height="21" opacity="1" fill="#3C6294" stroke="none"/>
+<rect x="798" y="178" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="898" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+39.8
 </text>
-<text x="898" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.5%
-</text>
-<text x="28" y="263" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="253" width="200" height="21" opacity="1" fill="#416BA2" stroke="none"/>
-<text x="286" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-45.1
-</text>
-<text x="286" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="898" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.5%
 </text>
-<rect x="390" y="253" width="200" height="21" opacity="1" fill="#375A88" stroke="none"/>
+<text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+concurrent-queue 2.5.0
+</text>
+<rect x="186" y="203" width="200" height="21" opacity="1" fill="#2C4669" stroke="none"/>
+<text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+22.7
+</text>
+<text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.5%
+</text>
+<rect x="390" y="203" width="200" height="21" opacity="1" fill="#23344F" stroke="none"/>
+<text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+12.3
+</text>
+<text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="594" y="203" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<text x="694" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.7
+</text>
+<text x="694" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="798" y="203" width="200" height="21" opacity="1" fill="#1F2C43" stroke="none"/>
+<text x="898" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.5
+</text>
+<text x="898" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<text x="28" y="238" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+thingbuf 0.1.6
+</text>
+<rect x="186" y="228" width="200" height="21" opacity="1" fill="#2E486D" stroke="none"/>
+<text x="286" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+24.2
+</text>
+<text x="286" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="390" y="228" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<text x="490" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.6
+</text>
+<text x="490" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.4%
+</text>
+<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
+<text x="694" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.6
+</text>
+<text x="694" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="798" y="228" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
+<text x="898" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.9
+</text>
+<text x="898" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<text x="28" y="263" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="253" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
+<text x="286" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.0
+</text>
+<text x="286" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<rect x="390" y="253" width="200" height="21" opacity="1" fill="#1E2A40" stroke="none"/>
 <text x="490" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.8
+6.3
 </text>
 <text x="490" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.7%
 </text>
-<rect x="594" y="253" width="200" height="21" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="594" y="253" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="694" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.1
+4.3
 </text>
 <text x="694" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.6%
++/-0.0%
 </text>
-<rect x="798" y="253" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="798" y="253" width="200" height="21" opacity="1" fill="#1A2334" stroke="none"/>
 <text x="898" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.0
+1.7
 </text>
 <text x="898" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.5%
+</text>
+<text x="28" y="288" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="278" width="200" height="21" opacity="1" fill="#416BA2" stroke="none"/>
+<text x="286" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+45.1
+</text>
+<text x="286" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="390" y="278" width="200" height="21" opacity="1" fill="#375A88" stroke="none"/>
+<text x="490" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+34.8
+</text>
+<text x="490" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.7%
+</text>
+<rect x="594" y="278" width="200" height="21" opacity="1" fill="#2B4365" stroke="none"/>
+<text x="694" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+21.1
+</text>
+<text x="694" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-10.6%
+</text>
+<rect x="798" y="278" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
+<text x="898" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+9.0
+</text>
+<text x="898" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-3.4%
 </text>
-<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,293 1000,293 "/>
-<text x="512" y="309" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,318 1000,318 "/>
+<text x="512" y="334" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 bytes64 (64 B); median M items/s (+/- MAD); color scale 0-60; white outline = winner
 </text>
-<text x="28" y="340" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="28" y="365" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
 </text>
-<text x="592" y="332" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+<text x="592" y="357" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 producer threads
 </text>
-<text x="286" y="350" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+<text x="286" y="375" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 1
 </text>
-<text x="490" y="350" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+<text x="490" y="375" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 2
 </text>
-<text x="694" y="350" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+<text x="694" y="375" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 4
 </text>
-<text x="898" y="350" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+<text x="898" y="375" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 8
 </text>
-<text x="28" y="374" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
+<text x="28" y="399" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="364" width="200" height="21" opacity="1" fill="#426EA7" stroke="none"/>
-<text x="286" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="186" y="389" width="200" height="21" opacity="1" fill="#426EA7" stroke="none"/>
+<text x="286" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 35.3
 </text>
-<text x="286" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="286" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
-<rect x="390" y="364" width="200" height="21" opacity="1" fill="#416CA4" stroke="none"/>
-<rect x="390" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="490" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="390" y="389" width="200" height="21" opacity="1" fill="#416CA4" stroke="none"/>
+<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 34.4
 </text>
-<text x="490" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="594" y="364" width="200" height="21" opacity="1" fill="#416CA3" stroke="none"/>
-<rect x="594" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="694" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="594" y="389" width="200" height="21" opacity="1" fill="#416CA3" stroke="none"/>
+<text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 34.2
 </text>
-<text x="694" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
-<rect x="798" y="364" width="200" height="21" opacity="1" fill="#304C72" stroke="none"/>
-<rect x="798" y="364" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="898" y="370" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+<rect x="798" y="389" width="200" height="21" opacity="1" fill="#304C72" stroke="none"/>
+<text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 19.7
 </text>
-<text x="898" y="381" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<text x="28" y="399" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-crossbeam-channel 0.5.16
-</text>
-<rect x="186" y="389" width="200" height="21" opacity="1" fill="#4C7FC1" stroke="none"/>
-<text x="286" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-43.0
-</text>
-<text x="286" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.2%
-</text>
-<rect x="390" y="389" width="200" height="21" opacity="1" fill="#395D8C" stroke="none"/>
-<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-27.4
-</text>
-<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
-</text>
-<rect x="594" y="389" width="200" height="21" opacity="1" fill="#243551" stroke="none"/>
-<text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.7
-</text>
-<text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="798" y="389" width="200" height="21" opacity="1" fill="#23344E" stroke="none"/>
-<text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.9
-</text>
 <text x="898" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.4%
 </text>
 <text x="28" y="424" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-concurrent-queue 2.5.0
+crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="414" width="200" height="21" opacity="1" fill="#5EA2F6" stroke="none"/>
-<rect x="186" y="414" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="186" y="414" width="200" height="21" opacity="1" fill="#4C7FC1" stroke="none"/>
 <text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-58.7
+43.0
 </text>
 <text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.4%
++/-0.2%
 </text>
-<rect x="390" y="414" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<rect x="390" y="414" width="200" height="21" opacity="1" fill="#395D8C" stroke="none"/>
 <text x="490" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.8
+27.4
 </text>
 <text x="490" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-3.9%
 </text>
-<rect x="594" y="414" width="200" height="21" opacity="1" fill="#22334C" stroke="none"/>
+<rect x="594" y="414" width="200" height="21" opacity="1" fill="#243651" stroke="none"/>
 <text x="694" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.4
+9.7
 </text>
 <text x="694" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.1%
 </text>
-<rect x="798" y="414" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
+<rect x="798" y="414" width="200" height="21" opacity="1" fill="#23344E" stroke="none"/>
 <text x="898" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.2
+8.9
 </text>
 <text x="898" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
 <text x="28" y="449" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
+crossfire 3.1.19
 </text>
-<rect x="186" y="439" width="200" height="21" opacity="1" fill="#3D6497" stroke="none"/>
-<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.5
+<rect x="186" y="439" width="200" height="21" opacity="1" fill="#5896E4" stroke="none"/>
+<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+53.5
 </text>
-<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
+<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-2.1%
 </text>
-<rect x="390" y="439" width="200" height="21" opacity="1" fill="#213149" stroke="none"/>
-<text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.5
+<rect x="390" y="439" width="200" height="21" opacity="1" fill="#5B9CEC" stroke="none"/>
+<rect x="390" y="439" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+55.8
 </text>
-<text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
+<text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.6%
 </text>
-<rect x="594" y="439" width="200" height="21" opacity="1" fill="#21314A" stroke="none"/>
-<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-7.8
+<rect x="594" y="439" width="200" height="21" opacity="1" fill="#4A7CBB" stroke="none"/>
+<rect x="594" y="439" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+41.3
 </text>
-<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.2%
+<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.9%
 </text>
-<rect x="798" y="439" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="798" y="439" width="200" height="21" opacity="1" fill="#3D6396" stroke="none"/>
+<rect x="798" y="439" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.9
+30.4
 </text>
 <text x="898" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.9%
++/-0.2%
 </text>
 <text x="28" y="474" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
-</text>
-<rect x="186" y="464" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
-<text x="286" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.4
-</text>
-<text x="286" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="390" y="464" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
-<text x="490" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.1
-</text>
-<text x="490" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.8%
-</text>
-<rect x="594" y="464" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
-<text x="694" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.8
-</text>
-<text x="694" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="798" y="464" width="200" height="21" opacity="1" fill="#192334" stroke="none"/>
-<text x="898" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.2
-</text>
-<text x="898" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
-</text>
-<text x="28" y="499" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
-</text>
-<rect x="186" y="489" width="200" height="21" opacity="1" fill="#2D486C" stroke="none"/>
-<text x="286" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-17.8
-</text>
-<text x="286" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="390" y="489" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
-<text x="490" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.3
-</text>
-<text x="490" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="594" y="489" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
-<text x="694" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.5
-</text>
-<text x="694" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="798" y="489" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
-<text x="898" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
-</text>
-<text x="898" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,529 1000,529 "/>
-<text x="512" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes256 (256 B); median M items/s (+/- MAD); color scale 0-40; white outline = winner
-</text>
-<text x="28" y="576" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-implementation
-</text>
-<text x="592" y="568" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
-producer threads
-</text>
-<text x="286" y="586" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-1
-</text>
-<text x="490" y="586" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-2
-</text>
-<text x="694" y="586" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-4
-</text>
-<text x="898" y="586" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-8
-</text>
-<text x="28" y="610" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
-fanring
-</text>
-<rect x="186" y="600" width="200" height="21" opacity="1" fill="#3E679C" stroke="none"/>
-<text x="286" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.4
-</text>
-<text x="286" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="390" y="600" width="200" height="21" opacity="1" fill="#3E679B" stroke="none"/>
-<rect x="390" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="490" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.3
-</text>
-<text x="490" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<rect x="594" y="600" width="200" height="21" opacity="1" fill="#3E669B" stroke="none"/>
-<rect x="594" y="600" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="694" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.1
-</text>
-<text x="694" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
-</text>
-<rect x="798" y="600" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
-<text x="898" y="606" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.9
-</text>
-<text x="898" y="617" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
-</text>
-<text x="28" y="635" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-crossbeam-channel 0.5.16
-</text>
-<rect x="186" y="625" width="200" height="21" opacity="1" fill="#4A7CBC" stroke="none"/>
-<text x="286" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-27.7
-</text>
-<text x="286" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
-</text>
-<rect x="390" y="625" width="200" height="21" opacity="1" fill="#314E76" stroke="none"/>
-<text x="490" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.8
-</text>
-<text x="490" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="594" y="625" width="200" height="21" opacity="1" fill="#283E5E" stroke="none"/>
-<text x="694" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-9.2
-</text>
-<text x="694" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="798" y="625" width="200" height="21" opacity="1" fill="#283D5D" stroke="none"/>
-<rect x="798" y="625" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="898" y="631" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.8
-</text>
-<text x="898" y="642" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<text x="28" y="660" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 concurrent-queue 2.5.0
 </text>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-33.5
+<rect x="186" y="464" width="200" height="21" opacity="1" fill="#5EA2F6" stroke="none"/>
+<rect x="186" y="464" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="286" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+58.7
 </text>
-<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
+<text x="286" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.4%
 </text>
-<rect x="390" y="650" width="200" height="21" opacity="1" fill="#2A4163" stroke="none"/>
+<rect x="390" y="464" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<text x="490" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.8
+</text>
+<text x="490" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<rect x="594" y="464" width="200" height="21" opacity="1" fill="#22334C" stroke="none"/>
+<text x="694" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.4
+</text>
+<text x="694" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<rect x="798" y="464" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
+<text x="898" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.2
+</text>
+<text x="898" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<text x="28" y="499" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+thingbuf 0.1.6
+</text>
+<rect x="186" y="489" width="200" height="21" opacity="1" fill="#3D6497" stroke="none"/>
+<text x="286" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+30.5
+</text>
+<text x="286" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="390" y="489" width="200" height="21" opacity="1" fill="#213149" stroke="none"/>
+<text x="490" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.5
+</text>
+<text x="490" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="594" y="489" width="200" height="21" opacity="1" fill="#21314A" stroke="none"/>
+<text x="694" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+7.8
+</text>
+<text x="694" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.2%
+</text>
+<rect x="798" y="489" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
+<text x="898" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.9
+</text>
+<text x="898" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.9%
+</text>
+<text x="28" y="524" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="514" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="286" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.4
+</text>
+<text x="286" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="390" y="514" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
+<text x="490" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.1
+</text>
+<text x="490" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.8%
+</text>
+<rect x="594" y="514" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<text x="694" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.8
+</text>
+<text x="694" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="798" y="514" width="200" height="21" opacity="1" fill="#192334" stroke="none"/>
+<text x="898" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.2
+</text>
+<text x="898" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<text x="28" y="549" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="539" width="200" height="21" opacity="1" fill="#2D476C" stroke="none"/>
+<text x="286" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+17.8
+</text>
+<text x="286" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="390" y="539" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
+<text x="490" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+10.3
+</text>
+<text x="490" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="594" y="539" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="694" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.5
+</text>
+<text x="694" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="798" y="539" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="898" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.2
+</text>
+<text x="898" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,579 1000,579 "/>
+<text x="512" y="595" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+bytes256 (256 B); median M items/s (+/- MAD); color scale 0-40; white outline = winner
+</text>
+<text x="28" y="626" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+implementation
+</text>
+<text x="592" y="618" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+producer threads
+</text>
+<text x="286" y="636" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="490" y="636" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="694" y="636" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="898" y="636" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="28" y="660" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
+fanring
+</text>
+<rect x="186" y="650" width="200" height="21" opacity="1" fill="#3F679C" stroke="none"/>
+<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+21.4
+</text>
+<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="390" y="650" width="200" height="21" opacity="1" fill="#3E679C" stroke="none"/>
 <text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-10.0
+21.3
 </text>
 <text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-0.6%
 </text>
-<rect x="594" y="650" width="200" height="21" opacity="1" fill="#273B59" stroke="none"/>
+<rect x="594" y="650" width="200" height="21" opacity="1" fill="#3E669B" stroke="none"/>
 <text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.2
+21.1
 </text>
 <text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-1.1%
 </text>
 <rect x="798" y="650" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
 <text x="898" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.9
 </text>
 <text x="898" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.3%
 </text>
 <text x="28" y="685" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-thingbuf 0.1.6
+crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="675" width="200" height="21" opacity="1" fill="#3B6294" stroke="none"/>
-<text x="286" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.7
+<rect x="186" y="675" width="200" height="21" opacity="1" fill="#4A7CBC" stroke="none"/>
+<text x="286" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+27.7
 </text>
-<text x="286" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="286" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.1%
 </text>
-<rect x="390" y="675" width="200" height="21" opacity="1" fill="#23354F" stroke="none"/>
+<rect x="390" y="675" width="200" height="21" opacity="1" fill="#314E76" stroke="none"/>
 <text x="490" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.2
+13.8
 </text>
 <text x="490" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.3%
++/-0.5%
 </text>
-<rect x="594" y="675" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<rect x="594" y="675" width="200" height="21" opacity="1" fill="#293F5E" stroke="none"/>
 <text x="694" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.0
+9.2
 </text>
 <text x="694" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.5%
 </text>
-<rect x="798" y="675" width="200" height="21" opacity="1" fill="#203048" stroke="none"/>
+<rect x="798" y="675" width="200" height="21" opacity="1" fill="#283D5C" stroke="none"/>
 <text x="898" y="681" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-4.7
+8.8
 </text>
 <text x="898" y="692" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-8.5%
++/-0.1%
 </text>
 <text x="28" y="710" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-flume 0.12.0
+crossfire 3.1.19
 </text>
-<rect x="186" y="700" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
-<text x="286" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.5
+<rect x="186" y="700" width="200" height="21" opacity="1" fill="#4E83C6" stroke="none"/>
+<text x="286" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+29.7
 </text>
-<text x="286" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
-</text>
-<rect x="390" y="700" width="200" height="21" opacity="1" fill="#1E2A3F" stroke="none"/>
-<text x="490" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-3.1
-</text>
-<text x="490" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="594" y="700" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
-<text x="694" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.2
-</text>
-<text x="694" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="286" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.6%
 </text>
-<rect x="798" y="700" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
+<rect x="390" y="700" width="200" height="21" opacity="1" fill="#4C80C1" stroke="none"/>
+<rect x="390" y="700" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="490" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+28.8
+</text>
+<text x="490" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.6%
+</text>
+<rect x="594" y="700" width="200" height="21" opacity="1" fill="#4C7FC0" stroke="none"/>
+<rect x="594" y="700" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="694" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+28.6
+</text>
+<text x="694" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.8%
+</text>
+<rect x="798" y="700" width="200" height="21" opacity="1" fill="#2B4264" stroke="none"/>
+<rect x="798" y="700" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-0.7
+10.3
 </text>
 <text x="898" y="717" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
 <text x="28" y="735" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-kanal 0.1.1
+concurrent-queue 2.5.0
 </text>
-<rect x="186" y="725" width="200" height="21" opacity="1" fill="#283D5C" stroke="none"/>
-<text x="286" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-8.6
+<rect x="186" y="725" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="186" y="725" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="286" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+33.5
 </text>
-<text x="286" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.7%
+<text x="286" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.4%
 </text>
-<rect x="390" y="725" width="200" height="21" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="390" y="725" width="200" height="21" opacity="1" fill="#2A4163" stroke="none"/>
 <text x="490" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-5.5
+10.0
 </text>
 <text x="490" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
++/-0.8%
 </text>
-<rect x="594" y="725" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="594" y="725" width="200" height="21" opacity="1" fill="#273B59" stroke="none"/>
 <text x="694" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-2.9
+8.2
 </text>
 <text x="694" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.0%
 </text>
-<rect x="798" y="725" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="798" y="725" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
 <text x="898" y="731" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-1.4
+6.9
 </text>
 <text x="898" y="742" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<text x="28" y="760" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+thingbuf 0.1.6
+</text>
+<rect x="186" y="750" width="200" height="21" opacity="1" fill="#3B6293" stroke="none"/>
+<text x="286" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.7
+</text>
+<text x="286" y="767" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="390" y="750" width="200" height="21" opacity="1" fill="#23354F" stroke="none"/>
+<text x="490" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+6.2
+</text>
+<text x="490" y="767" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.3%
+</text>
+<rect x="594" y="750" width="200" height="21" opacity="1" fill="#263B58" stroke="none"/>
+<text x="694" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.0
+</text>
+<text x="694" y="767" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.0%
+</text>
+<rect x="798" y="750" width="200" height="21" opacity="1" fill="#203048" stroke="none"/>
+<text x="898" y="756" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+4.7
+</text>
+<text x="898" y="767" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-8.5%
+</text>
+<text x="28" y="785" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+flume 0.12.0
+</text>
+<rect x="186" y="775" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
+<text x="286" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.5
+</text>
+<text x="286" y="792" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.0%
+</text>
+<rect x="390" y="775" width="200" height="21" opacity="1" fill="#1E2A40" stroke="none"/>
+<text x="490" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+3.1
+</text>
+<text x="490" y="792" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="594" y="775" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
+<text x="694" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.2
+</text>
+<text x="694" y="792" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="798" y="775" width="200" height="21" opacity="1" fill="#192234" stroke="none"/>
+<text x="898" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+0.7
+</text>
+<text x="898" y="792" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<text x="28" y="810" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+kanal 0.1.1
+</text>
+<rect x="186" y="800" width="200" height="21" opacity="1" fill="#273D5B" stroke="none"/>
+<text x="286" y="806" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+8.6
+</text>
+<text x="286" y="817" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.7%
+</text>
+<rect x="390" y="800" width="200" height="21" opacity="1" fill="#22324C" stroke="none"/>
+<text x="490" y="806" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+5.5
+</text>
+<text x="490" y="817" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.5%
+</text>
+<rect x="594" y="800" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
+<text x="694" y="806" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+2.9
+</text>
+<text x="694" y="817" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="798" y="800" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
+<text x="898" y="806" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+1.4
+</text>
+<text x="898" y="817" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,765 1000,765 "/>
-<text x="512" y="781" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">
+<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,840 1000,840 "/>
+<text x="512" y="856" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">
 Capacity: fanring uses per-ring HWM; others use one shared bound
 </text>
 </svg>

--- a/doc/charts/throughput-summary.svg
+++ b/doc/charts/throughput-summary.svg
@@ -30,19 +30,21 @@ million items/s
 100
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,318 830,318 "/>
-<rect x="123" y="164" width="44" height="154" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="169" y="280" width="44" height="38" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="215" y="298" width="44" height="20" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="261" y="301" width="44" height="17" opacity="1" fill="#A78BFA" stroke="none"/>
-<rect x="307" y="308" width="44" height="10" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="353" y="269" width="44" height="49" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="100" y="164" width="44" height="154" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="146" y="280" width="44" height="38" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="192" y="254" width="44" height="64" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="238" y="298" width="44" height="20" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="284" y="301" width="44" height="17" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="330" y="308" width="44" height="10" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="376" y="269" width="44" height="49" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="260" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPSC: 4 producers
 </text>
-<rect x="549" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="595" y="271" width="44" height="47" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="641" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="687" y="268" width="44" height="50" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="526" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="572" y="271" width="44" height="47" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="618" y="233" width="44" height="85" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="664" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<rect x="710" y="268" width="44" height="50" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="640" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPMC: 4 producers / 4 consumers
 </text>
@@ -54,20 +56,24 @@ fanring (4 x 2048-item rings)
 <text x="313" y="370" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 crossbeam-channel 0.5.16
 </text>
-<rect x="525" y="364" width="12" height="12" opacity="1" fill="#4ADE80" stroke="none"/>
+<rect x="525" y="364" width="12" height="12" opacity="1" fill="#22D3EE" stroke="none"/>
 <text x="543" y="370" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+crossfire 3.1.19
+</text>
+<rect x="65" y="384" width="12" height="12" opacity="1" fill="#4ADE80" stroke="none"/>
+<text x="83" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 concurrent-queue 2.5.0
 </text>
-<rect x="65" y="384" width="12" height="12" opacity="1" fill="#A78BFA" stroke="none"/>
-<text x="83" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+<rect x="295" y="384" width="12" height="12" opacity="1" fill="#A78BFA" stroke="none"/>
+<text x="313" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 thingbuf 0.1.6
 </text>
-<rect x="295" y="384" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<text x="313" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+<rect x="525" y="384" width="12" height="12" opacity="1" fill="#F472B6" stroke="none"/>
+<text x="543" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 flume 0.12.0
 </text>
-<rect x="525" y="384" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
-<text x="543" y="390" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
+<rect x="65" y="404" width="12" height="12" opacity="1" fill="#F59E0B" stroke="none"/>
+<text x="83" y="410" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E6EDF3">
 kanal 0.1.1
 </text>
 </svg>

--- a/src/bin/chart.rs
+++ b/src/bin/chart.rs
@@ -37,6 +37,8 @@ const SERIES: &[(&str, &str)] = &[
     ("fanring", "fanring"),
     ("fanring-mpmc", "fanring"),
     ("crossbeam-channel", "crossbeam-channel 0.5.16"),
+    ("crossfire", "crossfire 3.1.19"),
+    ("crossfire-mpmc", "crossfire 3.1.19"),
     ("concurrent-queue", "concurrent-queue 2.5.0"),
     ("thingbuf", "thingbuf 0.1.6"),
     ("flume", "flume 0.12.0"),
@@ -70,6 +72,8 @@ struct Row {
     high_watermark: u64,
     #[serde(alias = "msgs_per_sec")]
     items_per_sec: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    relative_mad: Option<f64>,
     #[serde(default)]
     sample: usize,
     #[serde(default = "render::one_sample")]
@@ -126,6 +130,7 @@ enum ChartError {
         path: PathBuf,
         source: std::io::Error,
     },
+    MissingResultsRoot,
     Draw(String),
     NoRows {
         path: PathBuf,
@@ -141,6 +146,9 @@ impl fmt::Display for ChartError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io { path, source } => write!(f, "{}: {source}", path.display()),
+            Self::MissingResultsRoot => {
+                f.write_str("HOME must be set unless FANRING_BENCH_CACHE_DIR is set")
+            }
             Self::Draw(error) => write!(f, "draw chart: {error}"),
             Self::NoRows { path } => write!(f, "no benchmark rows in {}", path.display()),
             Self::NoRenderableRows => f.write_str("no benchmark rows to render"),
@@ -148,10 +156,7 @@ impl fmt::Display for ChartError {
             Self::RunNotFound(run_id) => write!(f, "benchmark run id not found: {run_id}"),
             Self::RunIncomplete(run_id) => write!(f, "benchmark run is incomplete: {run_id}"),
             Self::InvalidTopology(topology) => {
-                write!(
-                    f,
-                    "invalid latency topology {topology:?}; expected mpsc or mpmc"
-                )
+                write!(f, "invalid topology {topology:?}; expected mpsc or mpmc")
             }
         }
     }
@@ -198,37 +203,35 @@ fn run() -> ChartResult<()> {
 }
 
 fn run_latency(topology: &str) -> ChartResult<()> {
-    let input = arg_value("--input").map_or_else(
-        || PathBuf::from("target/fanring-bench/wake-latency.jsonl"),
-        PathBuf::from,
-    );
+    let file_name = result_file_name("latency", topology)?;
+    let (inputs, source) = result_inputs(arg_value("--input"), file_name)?;
     let output = arg_value("--output").map_or_else(
         || PathBuf::from(format!("doc/charts/latency-{topology}.svg")),
         PathBuf::from,
     );
 
     prepare_output(&output)?;
-    latency::draw_latency_chart(&input, &output, topology, arg_value("--run"))?;
+    latency::draw_latency_chart(&inputs, &source, &output, topology, arg_value("--run"))?;
     println!("wrote {}", output.display());
     Ok(())
 }
 
 fn run_detail() -> ChartResult<()> {
-    let input = arg_value("--input").map_or_else(
-        || PathBuf::from("target/fanring-bench/results.jsonl"),
-        PathBuf::from,
-    );
+    let topology = if has_arg("--mpmc") { "mpmc" } else { "mpsc" };
+    let file_name = result_file_name("throughput", topology)?;
+    let (inputs, source) = result_inputs(arg_value("--input"), file_name)?;
     let output = arg_value("--output").map_or_else(
-        || PathBuf::from("doc/charts/throughput-mpsc.svg"),
+        || PathBuf::from(format!("doc/charts/throughput-{topology}.svg")),
         PathBuf::from,
     );
 
-    let rows = read_rows(&input)?;
+    let requested_run = arg_value("--run");
+    let rows = read_rows_from(&inputs)?;
     if rows.is_empty() {
-        return Err(ChartError::NoRows { path: input });
+        return Err(ChartError::NoRows { path: source });
     }
 
-    let rows = select_run_with_default_mode(rows, arg_value("--run"), Some(DEFAULT_CHART_MODE))?;
+    let rows = select_run_with_default_mode(rows, requested_run, Some(DEFAULT_CHART_MODE))?;
     prepare_output(&output)?;
     draw_chart(&rows, &output)?;
     println!("wrote {}", output.display());
@@ -236,27 +239,31 @@ fn run_detail() -> ChartResult<()> {
 }
 
 fn run_summary() -> ChartResult<()> {
-    let mpsc_input = arg_value("--mpsc-input").map_or_else(
-        || PathBuf::from("target/fanring-bench/results.jsonl"),
-        PathBuf::from,
-    );
-    let mpmc_input = arg_value("--mpmc-input").map_or_else(
-        || PathBuf::from("target/fanring-bench/mpmc.jsonl"),
-        PathBuf::from,
-    );
+    let (mpsc_inputs, mpsc_source) = result_inputs(
+        arg_value("--mpsc-input"),
+        result_file_name("throughput", "mpsc")?,
+    )?;
+    let (mpmc_inputs, mpmc_source) = result_inputs(
+        arg_value("--mpmc-input"),
+        result_file_name("throughput", "mpmc")?,
+    )?;
     let output = arg_value("--output").map_or_else(
         || PathBuf::from("doc/charts/throughput-summary.svg"),
         PathBuf::from,
     );
+    let mpsc_run = arg_value("--mpsc-run");
+    let mpmc_run = arg_value("--mpmc-run");
 
     let mpsc_rows = read_rows_for_run(
-        &mpsc_input,
-        arg_value("--mpsc-run"),
+        &mpsc_inputs,
+        &mpsc_source,
+        mpsc_run,
         Some(DEFAULT_CHART_MODE),
     )?;
     let mpmc_rows = read_rows_for_run(
-        &mpmc_input,
-        arg_value("--mpmc-run"),
+        &mpmc_inputs,
+        &mpmc_source,
+        mpmc_run,
         Some(DEFAULT_CHART_MODE),
     )?;
     prepare_output(&output)?;
@@ -266,17 +273,115 @@ fn run_summary() -> ChartResult<()> {
 }
 
 fn read_rows_for_run(
-    path: &Path,
+    inputs: &[PathBuf],
+    source: &Path,
     requested_run: Option<String>,
     default_mode: Option<&str>,
 ) -> ChartResult<Vec<Row>> {
-    let rows = read_rows(path)?;
+    let rows = read_rows_from(inputs)?;
     if rows.is_empty() {
         return Err(ChartError::NoRows {
-            path: path.to_path_buf(),
+            path: source.to_path_buf(),
         });
     }
     select_run_with_default_mode(rows, requested_run, default_mode)
+}
+
+fn result_file_name(metric: &str, topology: &str) -> ChartResult<String> {
+    match topology {
+        "mpsc" | "mpmc" => Ok(format!("{metric}-{topology}.jsonl")),
+        _ => Err(ChartError::InvalidTopology(topology.to_string())),
+    }
+}
+
+fn result_inputs(
+    explicit: Option<String>,
+    file_name: String,
+) -> ChartResult<(Vec<PathBuf>, PathBuf)> {
+    if let Some(path) = explicit {
+        let path = PathBuf::from(path);
+        return Ok((vec![path.clone()], path));
+    }
+
+    let root = results_root()?;
+    let source = root.join("*").join(&file_name);
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((Vec::new(), source));
+        }
+        Err(source) => {
+            return Err(ChartError::Io { path: root, source });
+        }
+    };
+    let mut inputs = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|source| ChartError::Io {
+            path: root.clone(),
+            source,
+        })?;
+        let path = entry.path().join(&file_name);
+        if path.is_file() {
+            inputs.push(path);
+        }
+    }
+    inputs.sort_unstable();
+    Ok((inputs, source))
+}
+
+fn results_root() -> ChartResult<PathBuf> {
+    if let Some(path) = arg_value("--results-dir") {
+        return Ok(PathBuf::from(path));
+    }
+    if let Some(path) = std::env::var_os("FANRING_BENCH_CACHE_DIR") {
+        return Ok(PathBuf::from(path));
+    }
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join(".cache/fanring"))
+        .ok_or(ChartError::MissingResultsRoot)
+}
+
+fn read_rows_from(inputs: &[PathBuf]) -> ChartResult<Vec<Row>> {
+    let mut rows = Vec::new();
+    for input in inputs {
+        rows.extend(expand_cached_measurements(read_rows(input)?));
+    }
+    Ok(rows)
+}
+
+fn expand_cached_measurements(rows: Vec<Row>) -> Vec<Row> {
+    rows.into_iter()
+        .flat_map(|row| {
+            let Some(relative_mad) = row.relative_mad else {
+                return vec![row];
+            };
+            let samples = row.samples.max(1);
+            let delta = row.items_per_sec * relative_mad / 100.0;
+            (0..samples)
+                .map(|sample| {
+                    let mut sample_row = row.clone();
+                    sample_row.items_per_sec = if samples.is_multiple_of(2) {
+                        if sample < samples / 2 {
+                            row.items_per_sec - delta
+                        } else {
+                            row.items_per_sec + delta
+                        }
+                    } else {
+                        match sample.cmp(&(samples / 2)) {
+                            std::cmp::Ordering::Less => row.items_per_sec - delta,
+                            std::cmp::Ordering::Equal => row.items_per_sec,
+                            std::cmp::Ordering::Greater => row.items_per_sec + delta,
+                        }
+                    };
+                    sample_row.relative_mad = None;
+                    sample_row.sample = sample;
+                    sample_row.expected_rows = row.expected_rows.saturating_mul(samples);
+                    sample_row
+                })
+                .collect()
+        })
+        .collect()
 }
 
 fn select_run_with_default_mode(
@@ -303,7 +408,7 @@ fn select_run_with_default_mode(
 
 fn combine_latest_runs(rows: &[Row], mode: Option<&str>) -> Option<Vec<Row>> {
     let mut seen = BTreeSet::new();
-    let run_ids = rows
+    let mut run_ids = rows
         .iter()
         .filter(|row| mode.is_none_or(|mode| row.mode == mode))
         .filter_map(|row| {
@@ -311,6 +416,7 @@ fn combine_latest_runs(rows: &[Row], mode: Option<&str>) -> Option<Vec<Row>> {
                 .then_some(row.run_id.as_str())
         })
         .collect::<Vec<_>>();
+    run_ids.sort_by_key(|run_id| run_id.parse::<u128>().unwrap_or(0));
     let complete_runs = run_ids
         .into_iter()
         .filter_map(|run_id| {
@@ -464,7 +570,34 @@ fn read_rows(path: &Path) -> ChartResult<Vec<Row>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Row, select_run_with_default_mode};
+    use super::{Row, expand_cached_measurements, select_run_with_default_mode};
+    use crate::render::measurement;
+
+    #[test]
+    fn cached_median_and_mad_expand_without_changing_measurement() {
+        let mut cached = row("cache:fanring", "try", "fanring", 1, 1);
+        cached.items_per_sec = 100.0;
+        cached.relative_mad = Some(10.0);
+        cached.samples = 5;
+        cached.expected_rows = 2;
+
+        let rows = expand_cached_measurements(vec![cached]);
+        let restored = measurement(rows.iter().map(|row| row.items_per_sec).collect());
+
+        assert_eq!(rows.len(), 5);
+        assert!(rows.iter().all(|row| row.expected_rows == 10));
+        assert_eq!(restored.median, 100.0);
+        assert!((restored.relative_mad - 10.0).abs() < f64::EPSILON);
+
+        let mut cached = rows[0].clone();
+        cached.items_per_sec = 100.0;
+        cached.relative_mad = Some(10.0);
+        cached.samples = 4;
+        let rows = expand_cached_measurements(vec![cached]);
+        let restored = measurement(rows.iter().map(|row| row.items_per_sec).collect());
+        assert_eq!(restored.median, 100.0);
+        assert!((restored.relative_mad - 10.0).abs() < f64::EPSILON);
+    }
 
     #[test]
     fn chart_default_ignores_newer_blocking_run() {
@@ -588,6 +721,7 @@ mod tests {
             low_watermark: 1,
             high_watermark: 1,
             items_per_sec: 1.0,
+            relative_mad: None,
             sample: 0,
             samples: 1,
             expected_rows,

--- a/src/bin/chart/latency.rs
+++ b/src/bin/chart/latency.rs
@@ -367,8 +367,13 @@ fn draw(rows: &[&LatencyRow], series: &[Series], topology: &str, output: &Path) 
     draw_y_grid(&area, plot_left, plot_right, plot_top, plot_bottom, y_max)?;
 
     let group_width = (plot_right - plot_left) / METRICS.len() as f64;
-    let bar_width = if series.len() == 5 { 30.0 } else { 36.0 };
     let bar_gap = 3.0;
+    let minimum_group_gap = 24.0;
+    let preferred_bar_width: f64 = if series.len() == 5 { 30.0 } else { 36.0 };
+    let available_bar_width =
+        (group_width - minimum_group_gap - series.len().saturating_sub(1) as f64 * bar_gap)
+            / series.len() as f64;
+    let bar_width = preferred_bar_width.min(available_bar_width);
     let cluster_width =
         series.len() as f64 * bar_width + series.len().saturating_sub(1) as f64 * bar_gap;
     for (metric_index, metric) in METRICS.iter().enumerate() {

--- a/src/bin/chart/latency.rs
+++ b/src/bin/chart/latency.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use plotters::coord::Shift;
 use plotters::prelude::*;
@@ -24,6 +24,7 @@ const MPSC_SERIES: &[Series] = &[
         "crossbeam-channel 0.5.16",
         RGBColor(0x60, 0xa5, 0xfa),
     ),
+    Series::new("crossfire", "crossfire 3.1.19", RGBColor(0x22, 0xd3, 0xee)),
     Series::new("thingbuf", "thingbuf 0.1.6", RGBColor(0xa7, 0x8b, 0xfa)),
     Series::new("flume", "flume 0.12.0", RGBColor(0xf4, 0x72, 0xb6)),
     Series::new("kanal", "kanal 0.1.1*", RGBColor(0xf5, 0x9e, 0x0b)),
@@ -35,6 +36,11 @@ const MPMC_SERIES: &[Series] = &[
         "crossbeam-channel",
         "crossbeam-channel 0.5.16",
         RGBColor(0x60, 0xa5, 0xfa),
+    ),
+    Series::new(
+        "crossfire-mpmc",
+        "crossfire 3.1.19",
+        RGBColor(0x22, 0xd3, 0xee),
     ),
     Series::new("flume", "flume 0.12.0", RGBColor(0xf4, 0x72, 0xb6)),
     Series::new("kanal", "kanal 0.1.1*", RGBColor(0xf5, 0x9e, 0x0b)),
@@ -98,10 +104,26 @@ struct LatencyRow {
     p99_ns: u64,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LatencyShape {
+    cpu: String,
+    capacity: usize,
+    rounds: usize,
+    settle_mode: String,
+    settle_ns: u64,
+}
+
+struct ImplementationRun<'a> {
+    implementation: &'static str,
+    shape: LatencyShape,
+    rows: Vec<&'a LatencyRow>,
+}
+
 type Area<'a> = DrawingArea<SVGBackend<'a>, Shift>;
 
 pub(super) fn draw_latency_chart(
-    input: &Path,
+    inputs: &[PathBuf],
+    source: &Path,
     output: &Path,
     topology: &str,
     requested_run: Option<String>,
@@ -111,10 +133,13 @@ pub(super) fn draw_latency_chart(
         "mpmc" => MPMC_SERIES,
         _ => return Err(ChartError::InvalidTopology(topology.to_string())),
     };
-    let rows = read_rows(input)?;
+    let mut rows = Vec::new();
+    for input in inputs {
+        rows.extend(read_rows(input)?);
+    }
     if rows.is_empty() {
         return Err(ChartError::NoRows {
-            path: input.to_path_buf(),
+            path: source.to_path_buf(),
         });
     }
     let rows = select_run(&rows, series, requested_run)?;
@@ -163,25 +188,83 @@ fn select_run<'a>(
         return complete_rows(&selected, series).ok_or(ChartError::RunIncomplete(run_id));
     }
 
+    combine_latest_runs(rows, series).ok_or(ChartError::NoCompleteRun)
+}
+
+fn combine_latest_runs<'a>(
+    rows: &'a [LatencyRow],
+    series: &[Series],
+) -> Option<Vec<&'a LatencyRow>> {
     let mut seen = BTreeSet::new();
-    let run_ids = rows
+    let mut run_ids = rows
         .iter()
         .filter_map(|row| {
             seen.insert(row.run_id.as_str())
                 .then_some(row.run_id.as_str())
         })
         .collect::<Vec<_>>();
-    run_ids
-        .into_iter()
-        .rev()
-        .find_map(|run_id| {
+    run_ids.sort_by_key(|run_id| run_id.parse::<u128>().unwrap_or(0));
+
+    let mut runs = Vec::new();
+    for run_id in run_ids {
+        for candidate in series {
             let selected = rows
                 .iter()
-                .filter(|row| row.run_id == run_id)
+                .filter(|row| row.run_id == run_id && row.implementation == candidate.key)
                 .collect::<Vec<_>>();
-            complete_rows(&selected, series)
-        })
-        .ok_or(ChartError::NoCompleteRun)
+            if let Some(shape) = complete_implementation(&selected) {
+                runs.push(ImplementationRun {
+                    implementation: candidate.key,
+                    shape,
+                    rows: selected,
+                });
+            }
+        }
+    }
+
+    for reference in runs.iter().rev().map(|run| &run.shape) {
+        let mut combined = Vec::new();
+        for candidate in series {
+            let Some(run) = runs
+                .iter()
+                .rev()
+                .find(|run| run.implementation == candidate.key && run.shape == *reference)
+            else {
+                combined.clear();
+                break;
+            };
+            combined.extend(run.rows.iter().copied());
+        }
+        if !combined.is_empty() {
+            return Some(combined);
+        }
+    }
+    None
+}
+
+fn complete_implementation(rows: &[&LatencyRow]) -> Option<LatencyShape> {
+    let first = *rows.first()?;
+    if rows.len() != 2
+        || rows
+            .iter()
+            .any(|row| latency_shape(row) != latency_shape(first))
+        || !["recv_wake", "send_wake"]
+            .iter()
+            .all(|operation| rows.iter().any(|row| row.operation == *operation))
+    {
+        return None;
+    }
+    Some(latency_shape(first))
+}
+
+fn latency_shape(row: &LatencyRow) -> LatencyShape {
+    LatencyShape {
+        cpu: row.cpu.clone(),
+        capacity: row.capacity,
+        rounds: row.rounds,
+        settle_mode: row.settle_mode.clone(),
+        settle_ns: row.settle_ns,
+    }
 }
 
 fn complete_rows<'a>(rows: &[&'a LatencyRow], series: &[Series]) -> Option<Vec<&'a LatencyRow>> {
@@ -528,6 +611,27 @@ mod tests {
         let selected = select_run(&rows, MPSC_SERIES, None).unwrap();
 
         assert!(selected.iter().all(|row| row.run_id == "new"));
+    }
+
+    #[test]
+    fn combines_latest_compatible_run_for_each_implementation() {
+        let mut rows = complete_run("1");
+        rows.extend([
+            row("2", "crossfire", "recv_wake"),
+            row("2", "crossfire", "send_wake"),
+        ]);
+
+        let selected = select_run(&rows, MPSC_SERIES, None).unwrap();
+
+        assert_eq!(selected.len(), MPSC_SERIES.len() * 2);
+        assert!(selected.iter().all(|row| {
+            row.run_id
+                == if row.implementation == "crossfire" {
+                    "2"
+                } else {
+                    "1"
+                }
+        }));
     }
 
     #[test]

--- a/src/bin/chart/render.rs
+++ b/src/bin/chart/render.rs
@@ -27,7 +27,7 @@ pub(super) fn draw_chart(rows: &[Row], output: &Path) -> ChartResult<()> {
     let payloads: Vec<String> = payloads.into_iter().map(|(payload, _)| payload).collect();
     let is_mpmc = rows.iter().any(|row| row.consumers.is_some());
     let width: u32 = if is_mpmc { 1440 } else { 1024 };
-    let section_h: u32 = 236;
+    let section_h: u32 = if is_mpmc { 236 } else { 261 };
     let header_h: u32 = 58;
     let footer_h: u32 = 24;
     let payload_count = u32::try_from(payloads.len()).expect("payload count fits u32");
@@ -187,7 +187,7 @@ fn draw_mpsc_heatmap(
         }
     }
 
-    draw_separator(area, y + 235, width)?;
+    draw_separator(area, y + 260, width)?;
     Ok(())
 }
 

--- a/src/bin/chart/summary.rs
+++ b/src/bin/chart/summary.rs
@@ -30,6 +30,12 @@ const SERIES: &[Series] = &[
         color: RGBColor(0x60, 0xa5, 0xfa),
     },
     Series {
+        mpsc_key: "crossfire",
+        mpmc_key: Some("crossfire-mpmc"),
+        label: "crossfire 3.1.19",
+        color: RGBColor(0x22, 0xd3, 0xee),
+    },
+    Series {
         mpsc_key: "concurrent-queue",
         mpmc_key: None,
         label: "concurrent-queue 2.5.0",
@@ -448,7 +454,13 @@ mod tests {
         let mpsc = summary_values(&mpsc.collect::<Vec<_>>(), false);
         let mpmc = summary_values(&mpmc.collect::<Vec<_>>(), true);
         assert_eq!(mpsc.len(), SERIES.len());
-        assert_eq!(mpmc.len(), 4);
+        assert_eq!(
+            mpmc.len(),
+            SERIES
+                .iter()
+                .filter(|series| series.mpmc_key.is_some())
+                .count()
+        );
         for series in SERIES {
             assert_eq!(mpsc.get(series.label), Some(&1.0));
             assert_eq!(mpmc.get(series.label), series.mpmc_key.map(|_| &1.0));
@@ -492,6 +504,7 @@ mod tests {
             low_watermark: 4096,
             high_watermark: 8192,
             items_per_sec: 1_000_000.0,
+            relative_mad: None,
             sample: 0,
             samples: 1,
             expected_rows: 1,

--- a/src/bin/chart/support.rs
+++ b/src/bin/chart/support.rs
@@ -112,6 +112,7 @@ mod tests {
             low_watermark: 1,
             high_watermark: 1,
             items_per_sec: 1.0,
+            relative_mad: None,
             sample,
             samples,
             expected_rows: samples,


### PR DESCRIPTION
- Add Crossfire to the MPSC and MPMC throughput and wake-latency benchmarks.
- Add Crossfire results to the throughput matrices, summary, and latency charts.
- Store benchmark results append-only under `~/.cache/fanring/<implementation>/`.
- Combine the newest compatible per-implementation histories when rendering charts.
- Add spacing between MPSC latency metric groups.