### PR TITLE
Reduce MPSC receive overhead and refresh throughput charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- Require yring 0.3.15 to eliminate intermediate ring-pop payload copies.
+
 ## [0.3.0] - 2026-09-03
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here.
 
 ### Changed
 
+- Reduce MPSC receive bookkeeping and intermediate payload moves between lane
+  maintenance boundaries.
 - Require yring 0.3.15 to eliminate intermediate ring-pop payload copies.
 
 ## [0.3.0] - 2026-09-03

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5955ee60ab48843f30e961ec82771716a733c8ecb6387f2d6fe9de9545ec9cb8"
+checksum = "27ba8401a75c66ab677bab9172bb8f7baa1e96cae3f0c25d7d5658930caffb89"
 dependencies = [
  "loom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ check-cfg = ["cfg(loom)"]
 [dependencies]
 arc-swap = "1.7"
 concurrent-queue = { version = "2.5", features = ["loom"] }
-yring = "0.3.14"
+yring = "0.3.15"
 
 [target.'cfg(all(loom, target_pointer_width = "64"))'.dependencies]
 loom = "0.7"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -80,6 +80,20 @@ looking up that page. After claiming lane bits, it refreshes again before
 looking up those lanes. A registration that races either snapshot is therefore
 imported before its claimed readiness bit is interpreted.
 
+Between release, rotation, and readiness-poll boundaries, `try_recv` leaves
+the front lane in its active deque and pops directly from that lane. Short
+prefetch windows are refreshed on this path too. Empty-lane handling and
+wakeups remain in the maintenance path, keeping its intermediate results out
+of ordinary payload reads. Blocking receives convert maintenance results
+directly to their own return type to avoid another payload-sized return through
+`try_recv`.
+
+The fast path updates the same burst, release, and readiness-poll counters as
+the maintenance path. It stops before a pop reaches either per-lane limit and
+is disabled when the readiness-poll budget is zero. Maintenance still performs
+every rotation, capacity release, and readiness poll, including when callers
+alternate blocking and nonblocking receives.
+
 `yring::prefetch` caches all flushed items with one Acquire load. Pops are
 non-atomic. Consumed capacity is released after `min(64, lane capacity)` items
 or when the lane reaches visible empty. A full release batch can span several

--- a/doc/charts/throughput-mpsc.svg
+++ b/doc/charts/throughput-mpsc.svg
@@ -7,7 +7,7 @@ fanring MPSC throughput comparison
 Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; all workers pinned, physical cores first; try operations; 5 samples; nominal capacity 8192 items; natural queue occupancy
 </text>
 <text x="512" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-u64 (8 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner
+u64 (8 B); median M items/s (+/- MAD); color scale 0-100; white outline = winner
 </text>
 <text x="28" y="104" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
@@ -30,61 +30,63 @@ producer threads
 <text x="28" y="138" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="128" width="200" height="21" opacity="1" fill="#5591DB" stroke="none"/>
+<rect x="186" y="128" width="200" height="21" opacity="1" fill="#4E83C6" stroke="none"/>
 <rect x="186" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-67.8
+74.3
 </text>
 <text x="286" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.5%
++/-2.2%
 </text>
-<rect x="390" y="128" width="200" height="21" opacity="1" fill="#548FD8" stroke="none"/>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="#5B9DED" stroke="none"/>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-66.6
+93.7
 </text>
 <text x="490" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.2%
++/-2.3%
 </text>
-<rect x="594" y="128" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="594" y="128" width="200" height="21" opacity="1" fill="#5FA3F7" stroke="none"/>
 <rect x="594" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-66.8
+98.4
 </text>
 <text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.5%
++/-0.5%
 </text>
-<rect x="798" y="128" width="200" height="21" opacity="1" fill="#345480" stroke="none"/>
+<rect x="798" y="128" width="200" height="21" opacity="1" fill="#385B89" stroke="none"/>
+<rect x="798" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-31.5
+44.1
 </text>
 <text x="898" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.3%
 </text>
 <text x="28" y="163" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="153" width="200" height="21" opacity="1" fill="#253855" stroke="none"/>
+<rect x="186" y="153" width="200" height="21" opacity="1" fill="#22334D" stroke="none"/>
 <text x="286" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14.5
 </text>
 <text x="286" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="390" y="153" width="200" height="21" opacity="1" fill="#355681" stroke="none"/>
+<rect x="390" y="153" width="200" height="21" opacity="1" fill="#2F4B71" stroke="none"/>
 <text x="490" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 32.2
 </text>
 <text x="490" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.9%
 </text>
-<rect x="594" y="153" width="200" height="21" opacity="1" fill="#273B59" stroke="none"/>
+<rect x="594" y="153" width="200" height="21" opacity="1" fill="#243651" stroke="none"/>
 <text x="694" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 16.4
 </text>
 <text x="694" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.3%
 </text>
-<rect x="798" y="153" width="200" height="21" opacity="1" fill="#22334D" stroke="none"/>
+<rect x="798" y="153" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
 <text x="898" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 11.5
 </text>
@@ -94,30 +96,28 @@ crossbeam-channel 0.5.16
 <text x="28" y="188" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossfire 3.1.19
 </text>
-<rect x="186" y="178" width="200" height="21" opacity="1" fill="#538DD5" stroke="none"/>
-<text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+<rect x="186" y="178" width="200" height="21" opacity="1" fill="#4777B4" stroke="none"/>
+<text x="286" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 65.4
 </text>
-<text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
+<text x="286" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="390" y="178" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
-<rect x="390" y="178" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+<rect x="390" y="178" width="200" height="21" opacity="1" fill="#4879B7" stroke="none"/>
+<text x="490" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 66.8
 </text>
-<text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
+<text x="490" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.7%
 </text>
-<rect x="594" y="178" width="200" height="21" opacity="1" fill="#314E76" stroke="none"/>
+<rect x="594" y="178" width="200" height="21" opacity="1" fill="#2C4568" stroke="none"/>
 <text x="694" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 27.6
 </text>
 <text x="694" y="195" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.9%
 </text>
-<rect x="798" y="178" width="200" height="21" opacity="1" fill="#3C6294" stroke="none"/>
-<rect x="798" y="178" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="798" y="178" width="200" height="21" opacity="1" fill="#355580" stroke="none"/>
 <text x="898" y="184" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 39.8
 </text>
@@ -127,28 +127,28 @@ crossfire 3.1.19
 <text x="28" y="213" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 concurrent-queue 2.5.0
 </text>
-<rect x="186" y="203" width="200" height="21" opacity="1" fill="#2C4669" stroke="none"/>
+<rect x="186" y="203" width="200" height="21" opacity="1" fill="#283E5E" stroke="none"/>
 <text x="286" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 22.7
 </text>
 <text x="286" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-6.5%
 </text>
-<rect x="390" y="203" width="200" height="21" opacity="1" fill="#23344F" stroke="none"/>
+<rect x="390" y="203" width="200" height="21" opacity="1" fill="#213049" stroke="none"/>
 <text x="490" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 12.3
 </text>
 <text x="490" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="594" y="203" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<rect x="594" y="203" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
 <text x="694" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.7
 </text>
 <text x="694" y="220" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="798" y="203" width="200" height="21" opacity="1" fill="#1F2C43" stroke="none"/>
+<rect x="798" y="203" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="898" y="209" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.5
 </text>
@@ -158,28 +158,28 @@ concurrent-queue 2.5.0
 <text x="28" y="238" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 thingbuf 0.1.6
 </text>
-<rect x="186" y="228" width="200" height="21" opacity="1" fill="#2E486D" stroke="none"/>
+<rect x="186" y="228" width="200" height="21" opacity="1" fill="#294061" stroke="none"/>
 <text x="286" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 24.2
 </text>
 <text x="286" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="390" y="228" width="200" height="21" opacity="1" fill="#202E46" stroke="none"/>
+<rect x="390" y="228" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
 <text x="490" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.6
 </text>
 <text x="490" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.4%
 </text>
-<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1F2D43" stroke="none"/>
+<rect x="594" y="228" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
 <text x="694" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.6
 </text>
 <text x="694" y="245" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="798" y="228" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
+<rect x="798" y="228" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="898" y="234" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.9
 </text>
@@ -189,28 +189,28 @@ thingbuf 0.1.6
 <text x="28" y="263" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="253" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
+<rect x="186" y="253" width="200" height="21" opacity="1" fill="#1E2B40" stroke="none"/>
 <text x="286" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.0
 </text>
 <text x="286" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
-<rect x="390" y="253" width="200" height="21" opacity="1" fill="#1E2A40" stroke="none"/>
+<rect x="390" y="253" width="200" height="21" opacity="1" fill="#1D283D" stroke="none"/>
 <text x="490" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.3
 </text>
 <text x="490" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.7%
 </text>
-<rect x="594" y="253" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
+<rect x="594" y="253" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
 <text x="694" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.3
 </text>
 <text x="694" y="270" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
-<rect x="798" y="253" width="200" height="21" opacity="1" fill="#1A2334" stroke="none"/>
+<rect x="798" y="253" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
 <text x="898" y="259" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 1.7
 </text>
@@ -220,28 +220,28 @@ flume 0.12.0
 <text x="28" y="288" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="278" width="200" height="21" opacity="1" fill="#416BA2" stroke="none"/>
+<rect x="186" y="278" width="200" height="21" opacity="1" fill="#385C8B" stroke="none"/>
 <text x="286" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 45.1
 </text>
 <text x="286" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.5%
 </text>
-<rect x="390" y="278" width="200" height="21" opacity="1" fill="#375A88" stroke="none"/>
+<rect x="390" y="278" width="200" height="21" opacity="1" fill="#314E76" stroke="none"/>
 <text x="490" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 34.8
 </text>
 <text x="490" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.7%
 </text>
-<rect x="594" y="278" width="200" height="21" opacity="1" fill="#2B4365" stroke="none"/>
+<rect x="594" y="278" width="200" height="21" opacity="1" fill="#273C5B" stroke="none"/>
 <text x="694" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 21.1
 </text>
 <text x="694" y="295" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-10.6%
 </text>
-<rect x="798" y="278" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="798" y="278" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
 <text x="898" y="284" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.0
 </text>
@@ -250,7 +250,7 @@ kanal 0.1.1
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,318 1000,318 "/>
 <text x="512" y="334" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
-bytes64 (64 B); median M items/s (+/- MAD); color scale 0-60; white outline = winner
+bytes64 (64 B); median M items/s (+/- MAD); color scale 0-80; white outline = winner
 </text>
 <text x="28" y="365" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
 implementation
@@ -273,59 +273,62 @@ producer threads
 <text x="28" y="399" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="389" width="200" height="21" opacity="1" fill="#426EA7" stroke="none"/>
+<rect x="186" y="389" width="200" height="21" opacity="1" fill="#365885" stroke="none"/>
 <text x="286" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-35.3
+33.7
 </text>
 <text x="286" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
++/-0.8%
 </text>
-<rect x="390" y="389" width="200" height="21" opacity="1" fill="#416CA4" stroke="none"/>
-<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.4
+<rect x="390" y="389" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="390" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+66.8
 </text>
-<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.1%
 </text>
-<rect x="594" y="389" width="200" height="21" opacity="1" fill="#416CA3" stroke="none"/>
-<text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.2
+<rect x="594" y="389" width="200" height="21" opacity="1" fill="#538ED7" stroke="none"/>
+<rect x="594" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+66.0
 </text>
-<text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.0%
+<text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.1%
 </text>
-<rect x="798" y="389" width="200" height="21" opacity="1" fill="#304C72" stroke="none"/>
+<rect x="798" y="389" width="200" height="21" opacity="1" fill="#365784" stroke="none"/>
+<rect x="798" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.7
+33.1
 </text>
 <text x="898" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-0.3%
 </text>
 <text x="28" y="424" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
 </text>
-<rect x="186" y="414" width="200" height="21" opacity="1" fill="#4C7FC1" stroke="none"/>
-<text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+<rect x="186" y="414" width="200" height="21" opacity="1" fill="#3F679D" stroke="none"/>
+<text x="286" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 43.0
 </text>
-<text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
+<text x="286" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="390" y="414" width="200" height="21" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="390" y="414" width="200" height="21" opacity="1" fill="#314E75" stroke="none"/>
 <text x="490" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 27.4
 </text>
 <text x="490" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-3.9%
 </text>
-<rect x="594" y="414" width="200" height="21" opacity="1" fill="#243651" stroke="none"/>
+<rect x="594" y="414" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
 <text x="694" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 9.7
 </text>
 <text x="694" y="431" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="798" y="414" width="200" height="21" opacity="1" fill="#23344E" stroke="none"/>
+<rect x="798" y="414" width="200" height="21" opacity="1" fill="#202F46" stroke="none"/>
 <text x="898" y="420" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.9
 </text>
@@ -335,31 +338,28 @@ crossbeam-channel 0.5.16
 <text x="28" y="449" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossfire 3.1.19
 </text>
-<rect x="186" y="439" width="200" height="21" opacity="1" fill="#5896E4" stroke="none"/>
-<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+<rect x="186" y="439" width="200" height="21" opacity="1" fill="#4879B7" stroke="none"/>
+<text x="286" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 53.5
 </text>
-<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
+<text x="286" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-2.1%
 </text>
-<rect x="390" y="439" width="200" height="21" opacity="1" fill="#5B9CEC" stroke="none"/>
-<rect x="390" y="439" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="390" y="439" width="200" height="21" opacity="1" fill="#4A7DBD" stroke="none"/>
 <text x="490" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
 55.8
 </text>
 <text x="490" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-1.6%
 </text>
-<rect x="594" y="439" width="200" height="21" opacity="1" fill="#4A7CBB" stroke="none"/>
-<rect x="594" y="439" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+<rect x="594" y="439" width="200" height="21" opacity="1" fill="#3D6598" stroke="none"/>
+<text x="694" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 41.3
 </text>
-<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
+<text x="694" y="456" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.9%
 </text>
-<rect x="798" y="439" width="200" height="21" opacity="1" fill="#3D6396" stroke="none"/>
-<rect x="798" y="439" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="798" y="439" width="200" height="21" opacity="1" fill="#33537D" stroke="none"/>
 <text x="898" y="445" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 30.4
 </text>
@@ -369,7 +369,7 @@ crossfire 3.1.19
 <text x="28" y="474" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 concurrent-queue 2.5.0
 </text>
-<rect x="186" y="464" width="200" height="21" opacity="1" fill="#5EA2F6" stroke="none"/>
+<rect x="186" y="464" width="200" height="21" opacity="1" fill="#4D82C4" stroke="none"/>
 <rect x="186" y="464" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
 58.7
@@ -377,21 +377,21 @@ concurrent-queue 2.5.0
 <text x="286" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
 +/-0.4%
 </text>
-<rect x="390" y="464" width="200" height="21" opacity="1" fill="#263A58" stroke="none"/>
+<rect x="390" y="464" width="200" height="21" opacity="1" fill="#23344E" stroke="none"/>
 <text x="490" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 11.8
 </text>
 <text x="490" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
-<rect x="594" y="464" width="200" height="21" opacity="1" fill="#22334C" stroke="none"/>
+<rect x="594" y="464" width="200" height="21" opacity="1" fill="#202E45" stroke="none"/>
 <text x="694" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 8.4
 </text>
 <text x="694" y="481" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.0%
 </text>
-<rect x="798" y="464" width="200" height="21" opacity="1" fill="#213048" stroke="none"/>
+<rect x="798" y="464" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
 <text x="898" y="470" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.2
 </text>
@@ -401,28 +401,28 @@ concurrent-queue 2.5.0
 <text x="28" y="499" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 thingbuf 0.1.6
 </text>
-<rect x="186" y="489" width="200" height="21" opacity="1" fill="#3D6497" stroke="none"/>
+<rect x="186" y="489" width="200" height="21" opacity="1" fill="#33537D" stroke="none"/>
 <text x="286" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 30.5
 </text>
 <text x="286" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="390" y="489" width="200" height="21" opacity="1" fill="#213149" stroke="none"/>
+<rect x="390" y="489" width="200" height="21" opacity="1" fill="#1F2C43" stroke="none"/>
 <text x="490" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.5
 </text>
 <text x="490" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="594" y="489" width="200" height="21" opacity="1" fill="#21314A" stroke="none"/>
+<rect x="594" y="489" width="200" height="21" opacity="1" fill="#1F2D44" stroke="none"/>
 <text x="694" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 7.8
 </text>
 <text x="694" y="506" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-4.2%
 </text>
-<rect x="798" y="489" width="200" height="21" opacity="1" fill="#202F47" stroke="none"/>
+<rect x="798" y="489" width="200" height="21" opacity="1" fill="#1E2B41" stroke="none"/>
 <text x="898" y="495" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 6.9
 </text>
@@ -432,28 +432,28 @@ thingbuf 0.1.6
 <text x="28" y="524" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 flume 0.12.0
 </text>
-<rect x="186" y="514" width="200" height="21" opacity="1" fill="#1E2C42" stroke="none"/>
+<rect x="186" y="514" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
 <text x="286" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 5.4
 </text>
 <text x="286" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="390" y="514" width="200" height="21" opacity="1" fill="#1D293E" stroke="none"/>
+<rect x="390" y="514" width="200" height="21" opacity="1" fill="#1C273A" stroke="none"/>
 <text x="490" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.1
 </text>
 <text x="490" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.8%
 </text>
-<rect x="594" y="514" width="200" height="21" opacity="1" fill="#1B2639" stroke="none"/>
+<rect x="594" y="514" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
 <text x="694" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2.8
 </text>
 <text x="694" y="531" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="798" y="514" width="200" height="21" opacity="1" fill="#192334" stroke="none"/>
+<rect x="798" y="514" width="200" height="21" opacity="1" fill="#192233" stroke="none"/>
 <text x="898" y="520" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 1.2
 </text>
@@ -463,28 +463,28 @@ flume 0.12.0
 <text x="28" y="549" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 kanal 0.1.1
 </text>
-<rect x="186" y="539" width="200" height="21" opacity="1" fill="#2D476C" stroke="none"/>
+<rect x="186" y="539" width="200" height="21" opacity="1" fill="#283E5D" stroke="none"/>
 <text x="286" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 17.8
 </text>
 <text x="286" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="390" y="539" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
+<rect x="390" y="539" width="200" height="21" opacity="1" fill="#21314A" stroke="none"/>
 <text x="490" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10.3
 </text>
 <text x="490" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="594" y="539" width="200" height="21" opacity="1" fill="#1D2A3F" stroke="none"/>
+<rect x="594" y="539" width="200" height="21" opacity="1" fill="#1C273B" stroke="none"/>
 <text x="694" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 4.5
 </text>
 <text x="694" y="556" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="798" y="539" width="200" height="21" opacity="1" fill="#1B2537" stroke="none"/>
+<rect x="798" y="539" width="200" height="21" opacity="1" fill="#1A2436" stroke="none"/>
 <text x="898" y="545" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 2.2
 </text>
@@ -516,33 +516,36 @@ producer threads
 <text x="28" y="660" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="#3F679C" stroke="none"/>
-<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.4
+<rect x="186" y="650" width="200" height="21" opacity="1" fill="#4F85CA" stroke="none"/>
+<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+30.5
 </text>
-<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
+<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.2%
 </text>
-<rect x="390" y="650" width="200" height="21" opacity="1" fill="#3E679C" stroke="none"/>
-<text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.3
+<rect x="390" y="650" width="200" height="21" opacity="1" fill="#5C9EF0" stroke="none"/>
+<rect x="390" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+38.0
 </text>
-<text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
+<text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.1%
 </text>
-<rect x="594" y="650" width="200" height="21" opacity="1" fill="#3E669B" stroke="none"/>
-<text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-21.1
+<rect x="594" y="650" width="200" height="21" opacity="1" fill="#5B9CED" stroke="none"/>
+<rect x="594" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+37.4
 </text>
-<text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.1%
+<text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.2%
 </text>
-<rect x="798" y="650" width="200" height="21" opacity="1" fill="#243753" stroke="none"/>
+<rect x="798" y="650" width="200" height="21" opacity="1" fill="#304D74" stroke="none"/>
+<rect x="798" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-6.9
+13.5
 </text>
 <text x="898" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.2%
 </text>
 <text x="28" y="685" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
@@ -586,7 +589,6 @@ crossfire 3.1.19
 +/-0.6%
 </text>
 <rect x="390" y="700" width="200" height="21" opacity="1" fill="#4C80C1" stroke="none"/>
-<rect x="390" y="700" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
 28.8
 </text>
@@ -594,7 +596,6 @@ crossfire 3.1.19
 +/-0.6%
 </text>
 <rect x="594" y="700" width="200" height="21" opacity="1" fill="#4C7FC0" stroke="none"/>
-<rect x="594" y="700" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
 28.6
 </text>
@@ -602,7 +603,6 @@ crossfire 3.1.19
 +/-0.8%
 </text>
 <rect x="798" y="700" width="200" height="21" opacity="1" fill="#2B4264" stroke="none"/>
-<rect x="798" y="700" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="706" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 10.3
 </text>

--- a/doc/charts/throughput-summary.svg
+++ b/doc/charts/throughput-summary.svg
@@ -9,40 +9,40 @@ Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off, all worke
 <text x="22" y="190" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 190)">
 million items/s
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,272 830,272 "/>
-<text x="62" y="272" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,273 830,273 "/>
+<text x="62" y="273" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 20
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,226 830,226 "/>
-<text x="62" y="226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,228 830,228 "/>
+<text x="62" y="228" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 40
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,180 830,180 "/>
-<text x="62" y="180" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,182 830,182 "/>
+<text x="62" y="182" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 60
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,134 830,134 "/>
-<text x="62" y="134" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,137 830,137 "/>
+<text x="62" y="137" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 80
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,88 830,88 "/>
-<text x="62" y="88" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,92 830,92 "/>
+<text x="62" y="92" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 100
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,318 830,318 "/>
-<rect x="100" y="164" width="44" height="154" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="146" y="280" width="44" height="38" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="192" y="254" width="44" height="64" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="100" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="146" y="281" width="44" height="37" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="192" y="256" width="44" height="62" opacity="1" fill="#22D3EE" stroke="none"/>
 <rect x="238" y="298" width="44" height="20" opacity="1" fill="#4ADE80" stroke="none"/>
 <rect x="284" y="301" width="44" height="17" opacity="1" fill="#A78BFA" stroke="none"/>
 <rect x="330" y="308" width="44" height="10" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="376" y="269" width="44" height="49" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="376" y="270" width="44" height="48" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="260" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPSC: 4 producers
 </text>
-<rect x="526" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="572" y="271" width="44" height="47" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="618" y="233" width="44" height="85" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="526" y="99" width="44" height="219" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="572" y="272" width="44" height="46" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="618" y="234" width="44" height="84" opacity="1" fill="#22D3EE" stroke="none"/>
 <rect x="664" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
 <rect x="710" y="268" width="44" height="50" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="640" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">

--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -37,6 +37,33 @@ impl<T> Receiver<T> {
     /// gone.
     #[inline]
     pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        // Keep the front lane in place between release, rotation, and readiness
+        // boundaries. Refresh short prefetch windows here as well: they do not
+        // require lane scheduling or a wakeup.
+        if self.items_until_ready_poll != 0
+            && let Some(&key) = self.active.front()
+            && let Some(lane) = self.lanes.get_mut(key.slot).and_then(Option::as_mut)
+            && lane.key == key
+        {
+            if lane.cached_available == 0 {
+                lane.cached_available = lane.consumer.prefetch();
+            }
+            if lane.cached_available != 0
+                && lane.unreleased + 1 < lane.release_batch
+                && lane.burst + 1 < PREFETCH_LIMIT
+            {
+                // Finish bookkeeping before loading T, so the payload does not
+                // pass through the maintenance path's intermediate results.
+                lane.cached_available -= 1;
+                lane.unreleased += 1;
+                lane.burst += 1;
+                self.items_until_ready_poll -= 1;
+                return Ok(lane
+                    .consumer
+                    .pop()
+                    .expect("cached_available guarantees prefetched data"));
+            }
+        }
         loop {
             let (result, released) = self.try_recv_inner();
             let retry = released.is_some() && matches!(result, Err(TryRecvError::Empty));
@@ -47,7 +74,8 @@ impl<T> Receiver<T> {
         }
     }
 
-    #[inline]
+    // Fold the intermediate result into each caller's return buffer.
+    #[inline(always)]
     fn try_recv_inner(&mut self) -> (Result<T, TryRecvError>, Option<LaneKey>) {
         loop {
             if self.active.is_empty() {
@@ -110,10 +138,18 @@ impl<T> Receiver<T> {
     /// Returns [`RecvError`] after all senders and buffered values are gone.
     #[inline]
     pub fn recv(&mut self) -> Result<T, RecvError> {
-        match self.try_recv() {
-            Ok(value) => Ok(value),
-            Err(TryRecvError::Disconnected) => Err(RecvError),
-            Err(TryRecvError::Empty) => self.recv_slow(),
+        // Convert directly to the blocking result type. Going through try_recv
+        // adds another payload-sized return on this path.
+        loop {
+            let (result, released) = self.try_recv_inner();
+            let retry = released.is_some() && matches!(result, Err(TryRecvError::Empty));
+            self.notify_released(released);
+            match result {
+                Ok(value) => return Ok(value),
+                Err(TryRecvError::Disconnected) => return Err(RecvError),
+                Err(TryRecvError::Empty) if retry => {}
+                Err(TryRecvError::Empty) => return self.recv_slow(),
+            }
         }
     }
 

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -273,6 +273,29 @@ fn reused_mpsc_lane_ignores_stale_generation_state() {
 }
 
 #[test]
+fn cached_mpsc_lane_refill_racing_sender_drop_preserves_values() {
+    model(|| {
+        let (mut tx, mut rx) = channel(4);
+        tx.try_send(0).unwrap();
+        tx.try_send(1).unwrap();
+        assert_eq!(rx.try_recv(), Ok(0));
+
+        let sender = thread::spawn(move || {
+            tx.try_send(2).unwrap();
+        });
+
+        assert_eq!(rx.try_recv(), Ok(1));
+        let result = rx.try_recv();
+        assert!(matches!(result, Ok(2) | Err(TryRecvError::Empty)));
+        sender.join().unwrap();
+        if result == Err(TryRecvError::Empty) {
+            assert_eq!(rx.try_recv(), Ok(2));
+        }
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
+    });
+}
+
+#[test]
 fn empty_short_lived_mpsc_lane_cannot_delay_disconnect() {
     model(|| {
         let (root, mut rx) = channel::<usize>(1);

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -436,6 +436,71 @@ fn empty_lane_releases_partial_credit_batch() {
 }
 
 #[test]
+fn release_batch_spans_short_prefetch_windows() {
+    let (mut tx, mut rx) = channel::<[u64; 8]>(128);
+
+    for value in 0..64 {
+        tx.try_send([value; 8]).unwrap();
+        assert_eq!(rx.try_recv(), Ok([value; 8]));
+    }
+
+    for value in 64..192 {
+        tx.try_send([value; 8]).unwrap();
+    }
+    assert_eq!(tx.try_send([192; 8]), Err(TrySendError::Full([192; 8])));
+    for value in 64..192 {
+        assert_eq!(rx.try_recv(), Ok([value; 8]));
+    }
+}
+
+#[test]
+fn cached_lane_rotation_survives_mixed_receive_calls() {
+    for mixed in [false, true] {
+        let (mut busy, mut rx) = channel(128);
+        let mut sparse = busy.try_clone().unwrap();
+        for sequence in 0..128 {
+            busy.try_send((0, sequence)).unwrap();
+        }
+        sparse.try_send((1, 0)).unwrap();
+
+        // Both lanes are ready before the first receive. The busy lane must
+        // yield after 64 items even when callers alternate receive methods.
+        for sequence in 0..64 {
+            let value = if mixed && sequence % 2 != 0 {
+                rx.recv().unwrap()
+            } else {
+                rx.try_recv().unwrap()
+            };
+            assert_eq!(value, (0, sequence));
+        }
+        assert_eq!(rx.try_recv(), Ok((1, 0)));
+        assert_eq!(rx.try_recv(), Ok((0, 64)));
+    }
+}
+
+#[test]
+fn short_prefetch_windows_do_not_hide_new_sender() {
+    let (mut busy, mut rx) = channel(256);
+    busy.try_send((0, 0)).unwrap();
+    assert_eq!(rx.try_recv(), Ok((0, 0)));
+
+    let mut sparse = busy.try_clone().unwrap();
+    sparse.try_send((1, 0)).unwrap();
+    let mut expected = 1;
+    for value in 1..=129 {
+        busy.try_send((0, value)).unwrap();
+        match rx.try_recv().unwrap() {
+            (1, 0) => return,
+            value => {
+                assert_eq!(value, (0, expected));
+                expected += 1;
+            }
+        }
+    }
+    panic!("busy lane must not hide a newly registered sender");
+}
+
+#[test]
 fn disconnects_after_draining() {
     let (mut tx, mut rx) = channel(4);
     tx.try_send(7).unwrap();


### PR DESCRIPTION
- Require `yring` 0.3.15 to remove intermediate ring-pop payload copies.
- Reduce MPSC `try_recv` bookkeeping between maintenance boundaries and avoid an extra payload-sized return in `recv`.
- Preserve 64-item lane rotation and readiness polling, capacity release thresholds, and wakeup handling.
- Refresh fanring measurements in the MPSC and summary throughput charts.
