### PR TITLE
Update yring and preserve MPSC receive throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- Require yring 0.3.16 with corrected data/space wakeup handshakes.
+- Keep MPSC lane polling inlined when underlying ring operations grow, avoiding
+  extra receive calls and intermediate payload moves.
+
 ## [0.3.1] - 2026-09-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ba8401a75c66ab677bab9172bb8f7baa1e96cae3f0c25d7d5658930caffb89"
+checksum = "31a91641eed4a631bd04c32edcdb1bed67c11db023c86a0a6ada528375d4135d"
 dependencies = [
  "loom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ check-cfg = ["cfg(loom)"]
 [dependencies]
 arc-swap = "1.7"
 concurrent-queue = { version = "2.5", features = ["loom"] }
-yring = "0.3.15"
+yring = "0.3.16"
 
 [target.'cfg(all(loom, target_pointer_width = "64"))'.dependencies]
 loom = "0.7"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -88,6 +88,9 @@ of ordinary payload reads. Blocking receives convert maintenance results
 directly to their own return type to avoid another payload-sized return through
 `try_recv`.
 
+Lane polling is always inlined so changes inside yring do not turn the
+maintenance path into a separate per-message call with an intermediate result.
+
 The fast path updates the same burst, release, and readiness-poll counters as
 the maintenance path. It stops before a pop reaches either per-lane limit and
 is disabled when the readiness-poll budget is zero. Maintenance still performs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -199,7 +199,10 @@ cargo run --example fanring-chart -- --latency mpmc
 Default outputs: `doc/charts/latency-mpsc.svg` and
 `doc/charts/latency-mpmc.svg`.
 
-Chart subtitles use the ignored `.chart_hw` file in the repository root:
+Chart subtitles automatically use the nearest `.chart_hw` in the current
+directory or its ancestors. If none exists, they use `.chart_hw` in the build's
+source directory. This also works when running a copied chart binary from the
+repository or one of its subdirectories. The file is ignored by Git:
 
 ```text
 prefix=Linux VM on a 2018 Mac Mini

--- a/doc/charts/throughput-mpmc.svg
+++ b/doc/charts/throughput-mpmc.svg
@@ -84,129 +84,129 @@ fanring
 <rect x="186" y="149" width="71" height="25" opacity="1" fill="#3B6091" stroke="none"/>
 <rect x="186" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-72.2
+71.9
 </text>
 <text x="221" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.4%
 </text>
-<rect x="261" y="149" width="71" height="25" opacity="1" fill="#355580" stroke="none"/>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="#345480" stroke="none"/>
 <text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-59.6
+59.0
 </text>
 <text x="296" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.6%
 </text>
-<rect x="336" y="149" width="71" height="25" opacity="1" fill="#2F4A6F" stroke="none"/>
+<rect x="336" y="149" width="71" height="25" opacity="1" fill="#375986" stroke="none"/>
 <rect x="336" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-47.1
+64.1
 </text>
 <text x="371" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.1%
++/-5.2%
 </text>
-<rect x="411" y="149" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="#273C5A" stroke="none"/>
 <rect x="411" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.8
+31.1
 </text>
 <text x="446" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-19.3%
++/-20.9%
 </text>
 <rect x="494" y="149" width="71" height="25" opacity="1" fill="#3A5F90" stroke="none"/>
 <rect x="494" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-71.2
+71.4
 </text>
 <text x="529" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.3%
 </text>
 <rect x="569" y="149" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
 <rect x="569" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-63.0
+62.8
 </text>
 <text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.0%
 </text>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4D83C6" stroke="none"/>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4D82C5" stroke="none"/>
 <rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-111.1
+110.6
 </text>
 <text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.5%
++/-2.6%
 </text>
-<rect x="719" y="149" width="71" height="25" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="#395D8D" stroke="none"/>
 <rect x="719" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-68.5
+68.7
 </text>
 <text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.0%
++/-0.9%
 </text>
 <rect x="802" y="149" width="71" height="25" opacity="1" fill="#3A5F90" stroke="none"/>
 <rect x="802" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="837" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-71.4
+71.2
 </text>
 <text x="837" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.3%
 </text>
-<rect x="877" y="149" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
+<rect x="877" y="149" width="71" height="25" opacity="1" fill="#365784" stroke="none"/>
 <rect x="877" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-63.0
+62.5
 </text>
 <text x="912" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.3%
 </text>
-<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4676B2" stroke="none"/>
+<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4675B2" stroke="none"/>
 <rect x="952" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="987" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-96.8
+96.4
 </text>
 <text x="987" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-0.7%
 </text>
 <rect x="1027" y="149" width="71" height="25" opacity="1" fill="#60A5F9" stroke="none"/>
 <rect x="1027" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-149.6
+149.5
 </text>
 <text x="1062" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-3.6%
++/-1.2%
 </text>
 <rect x="1110" y="149" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
 <rect x="1110" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1145" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.7
+30.3
 </text>
 <text x="1145" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#2A4163" stroke="none"/>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <rect x="1185" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-37.5
+36.2
 </text>
 <text x="1220" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.1%
 </text>
-<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#3B6193" stroke="none"/>
+<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#3A5F90" stroke="none"/>
 <rect x="1260" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-73.5
+71.5
 </text>
 <text x="1295" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.2%
 </text>
-<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#5999E7" stroke="none"/>
+<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#5D9FF1" stroke="none"/>
 <rect x="1335" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-136.0
+143.4
 </text>
 <text x="1370" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.1%
++/-0.9%
 </text>
 <text x="28" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
@@ -745,68 +745,68 @@ implementation
 <text x="28" y="397" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="385" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
+<rect x="186" y="385" width="71" height="25" opacity="1" fill="#2A4163" stroke="none"/>
 <text x="221" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.7
+25.0
 </text>
 <text x="221" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.2%
 </text>
 <rect x="261" y="385" width="71" height="25" opacity="1" fill="#304C73" stroke="none"/>
 <text x="296" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 33.1
 </text>
 <text x="296" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.6%
 </text>
-<rect x="336" y="385" width="71" height="25" opacity="1" fill="#395C8C" stroke="none"/>
+<rect x="336" y="385" width="71" height="25" opacity="1" fill="#3A5F8F" stroke="none"/>
 <rect x="336" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-45.4
+47.2
 </text>
 <text x="371" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.9%
 </text>
-<rect x="411" y="385" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
+<rect x="411" y="385" width="71" height="25" opacity="1" fill="#2C4669" stroke="none"/>
 <rect x="411" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.3
+28.4
 </text>
 <text x="446" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-9.0%
++/-1.7%
 </text>
 <rect x="494" y="385" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
 <text x="529" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-24.6
+24.7
 </text>
 <text x="529" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.4%
 </text>
 <rect x="569" y="385" width="71" height="25" opacity="1" fill="#304D74" stroke="none"/>
 <rect x="569" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.8
+33.6
 </text>
 <text x="604" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="644" y="385" width="71" height="25" opacity="1" fill="#4776B2" stroke="none"/>
+<rect x="644" y="385" width="71" height="25" opacity="1" fill="#4674B0" stroke="none"/>
 <rect x="644" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="679" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-64.6
+63.4
 </text>
 <text x="679" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.9%
 </text>
-<rect x="719" y="385" width="71" height="25" opacity="1" fill="#426DA6" stroke="none"/>
+<rect x="719" y="385" width="71" height="25" opacity="1" fill="#4471AB" stroke="none"/>
 <rect x="719" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-58.2
+61.1
 </text>
 <text x="754" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.7%
++/-1.5%
 </text>
-<rect x="802" y="385" width="71" height="25" opacity="1" fill="#2A4161" stroke="none"/>
+<rect x="802" y="385" width="71" height="25" opacity="1" fill="#2A4162" stroke="none"/>
 <rect x="802" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="837" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 24.5
@@ -814,34 +814,34 @@ fanring
 <text x="837" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.2%
 </text>
-<rect x="877" y="385" width="71" height="25" opacity="1" fill="#304D74" stroke="none"/>
+<rect x="877" y="385" width="71" height="25" opacity="1" fill="#304C73" stroke="none"/>
 <rect x="877" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.5
+33.0
 </text>
 <text x="912" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="952" y="385" width="71" height="25" opacity="1" fill="#3F679C" stroke="none"/>
-<rect x="952" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-53.7
-</text>
-<text x="987" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.9%
 </text>
-<rect x="1027" y="385" width="71" height="25" opacity="1" fill="#5B9CEC" stroke="none"/>
+<rect x="952" y="385" width="71" height="25" opacity="1" fill="#3E669A" stroke="none"/>
+<rect x="952" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="987" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+52.7
+</text>
+<text x="987" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.2%
+</text>
+<rect x="1027" y="385" width="71" height="25" opacity="1" fill="#5A9AE9" stroke="none"/>
 <rect x="1027" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-92.9
+91.5
 </text>
 <text x="1062" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-0.3%
 </text>
-<rect x="1110" y="385" width="71" height="25" opacity="1" fill="#23344E" stroke="none"/>
+<rect x="1110" y="385" width="71" height="25" opacity="1" fill="#23334E" stroke="none"/>
 <rect x="1110" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1145" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14.7
+14.6
 </text>
 <text x="1145" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
@@ -849,26 +849,26 @@ fanring
 <rect x="1185" y="385" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
 <rect x="1185" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1220" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-20.3
+20.4
 </text>
 <text x="1220" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.2%
 </text>
 <rect x="1260" y="385" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
 <rect x="1260" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-40.8
+40.7
 </text>
 <text x="1295" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.3%
 </text>
-<rect x="1335" y="385" width="71" height="25" opacity="1" fill="#5998E6" stroke="none"/>
+<rect x="1335" y="385" width="71" height="25" opacity="1" fill="#5896E3" stroke="none"/>
 <rect x="1335" y="385" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="393" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-90.2
+88.7
 </text>
 <text x="1370" y="404" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-1.1%
 </text>
 <text x="28" y="426" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
@@ -1409,67 +1409,67 @@ implementation
 <text x="28" y="633" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="621" width="71" height="25" opacity="1" fill="#294060" stroke="none"/>
+<rect x="186" y="621" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <text x="221" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14.4
 </text>
 <text x="221" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.3%
 </text>
-<rect x="261" y="621" width="71" height="25" opacity="1" fill="#32517A" stroke="none"/>
+<rect x="261" y="621" width="71" height="25" opacity="1" fill="#33517B" stroke="none"/>
 <rect x="261" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="296" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.0
+22.2
 </text>
 <text x="296" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.0%
++/-0.5%
 </text>
-<rect x="336" y="621" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
+<rect x="336" y="621" width="71" height="25" opacity="1" fill="#3B6091" stroke="none"/>
 <rect x="336" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-25.1
+28.8
 </text>
 <text x="371" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.5%
++/-1.2%
 </text>
-<rect x="411" y="621" width="71" height="25" opacity="1" fill="#2A4161" stroke="none"/>
+<rect x="411" y="621" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <rect x="411" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-14.7
+14.5
 </text>
 <text x="446" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.1%
++/-3.7%
 </text>
 <rect x="494" y="621" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <text x="529" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 14.5
 </text>
 <text x="529" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.4%
 </text>
-<rect x="569" y="621" width="71" height="25" opacity="1" fill="#33537D" stroke="none"/>
+<rect x="569" y="621" width="71" height="25" opacity="1" fill="#33527C" stroke="none"/>
 <rect x="569" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.8
+22.6
 </text>
 <text x="604" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.4%
 </text>
-<rect x="644" y="621" width="71" height="25" opacity="1" fill="#4C81C3" stroke="none"/>
+<rect x="644" y="621" width="71" height="25" opacity="1" fill="#4D82C4" stroke="none"/>
 <rect x="644" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="679" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-43.6
+44.0
 </text>
 <text x="679" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-0.4%
 </text>
-<rect x="719" y="621" width="71" height="25" opacity="1" fill="#3D6598" stroke="none"/>
+<rect x="719" y="621" width="71" height="25" opacity="1" fill="#3F689D" stroke="none"/>
 <rect x="719" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="754" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-31.0
+32.4
 </text>
 <text x="754" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-1.3%
++/-1.7%
 </text>
 <rect x="802" y="621" width="71" height="25" opacity="1" fill="#294060" stroke="none"/>
 <rect x="802" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
@@ -1477,31 +1477,31 @@ fanring
 14.4
 </text>
 <text x="837" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.1%
 </text>
-<rect x="877" y="621" width="71" height="25" opacity="1" fill="#33527B" stroke="none"/>
+<rect x="877" y="621" width="71" height="25" opacity="1" fill="#33527C" stroke="none"/>
 <rect x="877" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-22.4
+22.5
 </text>
 <text x="912" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-0.3%
 </text>
-<rect x="952" y="621" width="71" height="25" opacity="1" fill="#406AA1" stroke="none"/>
+<rect x="952" y="621" width="71" height="25" opacity="1" fill="#406AA0" stroke="none"/>
 <rect x="952" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="987" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.6
+33.2
 </text>
 <text x="987" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.2%
 </text>
-<rect x="1027" y="621" width="71" height="25" opacity="1" fill="#5895E2" stroke="none"/>
+<rect x="1027" y="621" width="71" height="25" opacity="1" fill="#5795E2" stroke="none"/>
 <rect x="1027" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-53.0
+52.7
 </text>
 <text x="1062" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.3%
++/-0.2%
 </text>
 <rect x="1110" y="621" width="71" height="25" opacity="1" fill="#1E2C42" stroke="none"/>
 <text x="1145" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
@@ -1518,21 +1518,21 @@ fanring
 <text x="1220" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.1%
 </text>
-<rect x="1260" y="621" width="71" height="25" opacity="1" fill="#2F4A6F" stroke="none"/>
+<rect x="1260" y="621" width="71" height="25" opacity="1" fill="#2E496F" stroke="none"/>
 <rect x="1260" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.8
+18.6
 </text>
 <text x="1295" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-0.2%
 </text>
-<rect x="1335" y="621" width="71" height="25" opacity="1" fill="#5590DB" stroke="none"/>
+<rect x="1335" y="621" width="71" height="25" opacity="1" fill="#548FD9" stroke="none"/>
 <rect x="1335" y="621" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="629" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-50.7
+50.3
 </text>
 <text x="1370" y="640" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-0.7%
 </text>
 <text x="28" y="662" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16

--- a/doc/charts/throughput-mpsc.svg
+++ b/doc/charts/throughput-mpsc.svg
@@ -30,37 +30,37 @@ producer threads
 <text x="28" y="138" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="128" width="200" height="21" opacity="1" fill="#4E83C6" stroke="none"/>
+<rect x="186" y="128" width="200" height="21" opacity="1" fill="#4B7EBF" stroke="none"/>
 <rect x="186" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="286" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-74.3
+70.6
 </text>
 <text x="286" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-2.2%
++/-6.4%
 </text>
-<rect x="390" y="128" width="200" height="21" opacity="1" fill="#5B9DED" stroke="none"/>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="#5D9FF0" stroke="none"/>
 <rect x="390" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-93.7
+95.2
 </text>
 <text x="490" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-2.3%
++/-1.2%
 </text>
-<rect x="594" y="128" width="200" height="21" opacity="1" fill="#5FA3F7" stroke="none"/>
+<rect x="594" y="128" width="200" height="21" opacity="1" fill="#5D9FF1" stroke="none"/>
 <rect x="594" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-98.4
+95.6
 </text>
 <text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.5%
++/-1.2%
 </text>
-<rect x="798" y="128" width="200" height="21" opacity="1" fill="#385B89" stroke="none"/>
+<rect x="798" y="128" width="200" height="21" opacity="1" fill="#375987" stroke="none"/>
 <rect x="798" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-44.1
+42.9
 </text>
 <text x="898" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.6%
 </text>
 <text x="28" y="163" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
@@ -273,36 +273,36 @@ producer threads
 <text x="28" y="399" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="389" width="200" height="21" opacity="1" fill="#365885" stroke="none"/>
+<rect x="186" y="389" width="200" height="21" opacity="1" fill="#3A5E8E" stroke="none"/>
 <text x="286" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.7
+37.2
 </text>
 <text x="286" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-0.0%
 </text>
-<rect x="390" y="389" width="200" height="21" opacity="1" fill="#548FD9" stroke="none"/>
+<rect x="390" y="389" width="200" height="21" opacity="1" fill="#528AD2" stroke="none"/>
 <rect x="390" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-66.8
+64.0
 </text>
 <text x="490" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-0.6%
 </text>
-<rect x="594" y="389" width="200" height="21" opacity="1" fill="#538ED7" stroke="none"/>
+<rect x="594" y="389" width="200" height="21" opacity="1" fill="#5088CE" stroke="none"/>
 <rect x="594" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-66.0
+62.6
 </text>
 <text x="694" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-0.5%
 </text>
-<rect x="798" y="389" width="200" height="21" opacity="1" fill="#365784" stroke="none"/>
+<rect x="798" y="389" width="200" height="21" opacity="1" fill="#365783" stroke="none"/>
 <rect x="798" y="389" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="395" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-33.1
+32.8
 </text>
 <text x="898" y="406" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-0.8%
 </text>
 <text x="28" y="424" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16
@@ -516,36 +516,36 @@ producer threads
 <text x="28" y="660" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring
 </text>
-<rect x="186" y="650" width="200" height="21" opacity="1" fill="#4F85CA" stroke="none"/>
-<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-30.5
+<rect x="186" y="650" width="200" height="21" opacity="1" fill="#4879B7" stroke="none"/>
+<text x="286" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+26.7
 </text>
-<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.2%
+<text x="286" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.1%
 </text>
-<rect x="390" y="650" width="200" height="21" opacity="1" fill="#5C9EF0" stroke="none"/>
+<rect x="390" y="650" width="200" height="21" opacity="1" fill="#60A5F9" stroke="none"/>
 <rect x="390" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="490" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-38.0
+39.9
 </text>
 <text x="490" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.1%
++/-0.4%
 </text>
-<rect x="594" y="650" width="200" height="21" opacity="1" fill="#5B9CED" stroke="none"/>
+<rect x="594" y="650" width="200" height="21" opacity="1" fill="#5A9BEA" stroke="none"/>
 <rect x="594" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="694" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-37.4
+36.9
 </text>
 <text x="694" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.2%
++/-3.1%
 </text>
-<rect x="798" y="650" width="200" height="21" opacity="1" fill="#304D74" stroke="none"/>
+<rect x="798" y="650" width="200" height="21" opacity="1" fill="#314D75" stroke="none"/>
 <rect x="798" y="650" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="898" y="656" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-13.5
+13.7
 </text>
 <text x="898" y="667" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
++/-0.3%
 </text>
 <text x="28" y="685" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
 crossbeam-channel 0.5.16

--- a/doc/charts/throughput-summary.svg
+++ b/doc/charts/throughput-summary.svg
@@ -9,42 +9,42 @@ Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off, all worke
 <text x="22" y="190" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold" transform="rotate(270, 22, 190)">
 million items/s
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,273 830,273 "/>
-<text x="62" y="273" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,272 830,272 "/>
+<text x="62" y="272" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 20
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,228 830,228 "/>
-<text x="62" y="228" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,226 830,226 "/>
+<text x="62" y="226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 40
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,182 830,182 "/>
-<text x="62" y="182" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,179 830,179 "/>
+<text x="62" y="179" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 60
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,137 830,137 "/>
-<text x="62" y="137" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,133 830,133 "/>
+<text x="62" y="133" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 80
 </text>
-<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,92 830,92 "/>
-<text x="62" y="92" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
+<polyline fill="none" opacity="1" stroke="#21262D" stroke-width="1" points="70,87 830,87 "/>
+<text x="62" y="87" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#7D8590">
 100
 </text>
 <polyline fill="none" opacity="1" stroke="#30363D" stroke-width="2" points="70,318 830,318 "/>
-<rect x="100" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="146" y="281" width="44" height="37" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="192" y="256" width="44" height="62" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="100" y="97" width="44" height="221" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="146" y="280" width="44" height="38" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="192" y="254" width="44" height="64" opacity="1" fill="#22D3EE" stroke="none"/>
 <rect x="238" y="298" width="44" height="20" opacity="1" fill="#4ADE80" stroke="none"/>
-<rect x="284" y="301" width="44" height="17" opacity="1" fill="#A78BFA" stroke="none"/>
+<rect x="284" y="300" width="44" height="18" opacity="1" fill="#A78BFA" stroke="none"/>
 <rect x="330" y="308" width="44" height="10" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="376" y="270" width="44" height="48" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="376" y="269" width="44" height="49" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="260" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPSC: 4 producers
 </text>
-<rect x="526" y="99" width="44" height="219" opacity="1" fill="#F87171" stroke="none"/>
-<rect x="572" y="272" width="44" height="46" opacity="1" fill="#60A5FA" stroke="none"/>
-<rect x="618" y="234" width="44" height="84" opacity="1" fill="#22D3EE" stroke="none"/>
+<rect x="526" y="95" width="44" height="223" opacity="1" fill="#F87171" stroke="none"/>
+<rect x="572" y="271" width="44" height="47" opacity="1" fill="#60A5FA" stroke="none"/>
+<rect x="618" y="232" width="44" height="86" opacity="1" fill="#22D3EE" stroke="none"/>
 <rect x="664" y="306" width="44" height="12" opacity="1" fill="#F472B6" stroke="none"/>
-<rect x="710" y="268" width="44" height="50" opacity="1" fill="#F59E0B" stroke="none"/>
+<rect x="710" y="267" width="44" height="51" opacity="1" fill="#F59E0B" stroke="none"/>
 <text x="640" y="338" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#E6EDF3" font-weight="bold">
 MPMC: 4 producers / 4 consumers
 </text>

--- a/src/bin/chart/hardware.rs
+++ b/src/bin/chart/hardware.rs
@@ -22,7 +22,17 @@ fn configured_hardware() -> Option<String> {
 }
 
 fn read_chart_hardware() -> BTreeMap<String, String> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".chart_hw");
+    let working_dir = std::env::current_dir().unwrap_or_default();
+    read_chart_hardware_from(&working_dir, Path::new(env!("CARGO_MANIFEST_DIR")))
+}
+
+fn read_chart_hardware_from(working_dir: &Path, manifest_dir: &Path) -> BTreeMap<String, String> {
+    // A copied or installed binary must use the checkout it is running in.
+    let path = working_dir
+        .ancestors()
+        .map(|dir| dir.join(".chart_hw"))
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| manifest_dir.join(".chart_hw"));
     let Ok(content) = std::fs::read_to_string(path) else {
         return BTreeMap::new();
     };
@@ -62,7 +72,43 @@ fn simplify_cpu_name(cpu: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{join_hardware_parts, simplify_cpu_name};
+    use super::{join_hardware_parts, read_chart_hardware_from, simplify_cpu_name};
+
+    #[test]
+    fn reads_runtime_repo_hardware_after_relocated_build() {
+        let root =
+            std::env::temp_dir().join(format!("fanring-chart-hardware-{}", std::process::id()));
+        let repo = root.join("runtime-repo");
+        let nested = repo.join("doc/charts");
+        let build = root.join("isolated-build");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(&build).unwrap();
+        std::fs::write(
+            repo.join(".chart_hw"),
+            "prefix=runtime host\npostfix=turbo off\n",
+        )
+        .unwrap();
+        std::fs::write(build.join(".chart_hw"), "label=stale build host\n").unwrap();
+
+        let from_root = read_chart_hardware_from(&repo, &build);
+        let from_nested = read_chart_hardware_from(&nested, &build);
+        std::fs::remove_file(repo.join(".chart_hw")).unwrap();
+        let fallback = read_chart_hardware_from(&repo, &build);
+        std::fs::remove_file(build.join(".chart_hw")).unwrap();
+        let missing = read_chart_hardware_from(&repo, &build);
+        std::fs::remove_dir_all(root).unwrap();
+
+        assert_eq!(
+            from_root.get("prefix").map(String::as_str),
+            Some("runtime host")
+        );
+        assert_eq!(from_nested, from_root);
+        assert_eq!(
+            fallback.get("label").map(String::as_str),
+            Some("stale build host")
+        );
+        assert!(missing.is_empty());
+    }
 
     #[test]
     fn joins_configured_hardware_parts() {

--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -269,7 +269,9 @@ impl<T> Receiver<T> {
         }
     }
 
-    #[inline]
+    // Keep LanePoll in the caller. Extra yring branches can otherwise exceed
+    // the compiler's inline budget and add a call/return to every blocking recv.
+    #[inline(always)]
     fn poll_lane(&mut self, key: LaneKey) -> LanePoll<T> {
         let Some(lane) = self.lanes.get_mut(key.slot).and_then(Option::as_mut) else {
             return LanePoll::Stale;


### PR DESCRIPTION
- Require published `yring` 0.3.16 with corrected wakeup handshakes.
- Keep MPSC lane polling inlined to preserve receive throughput with the updated ring.
- Read chart subtitles automatically from runtime `.chart_hw`; refresh throughput charts.
