### PR TITLE
Add selectable channel teardown policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Per-channel `Deferred` and `Coordinated` teardown policies, selected with
+  `channel_with_policy` or `try_channel_with_policy`. Existing constructors use
+  Deferred and preserve their send path without cleanup coordination.
+- Coordinated teardown destroys unread payloads while sender handles remain
+  alive. Overlapping sends reclaim late publications when they resume, without
+  making receiver teardown wait for a paused producer.
+
 ## [0.3.2] - 2026-09-08
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
     "LICENSE",
     "CHANGELOG.md",
     "DESIGN.md",
+    "doc/teardown.md",
 ]
 
 [lints.rust]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,9 +43,14 @@ to a later sender.
 ## Send Path
 
 1. Check that the receiver is alive.
-2. Push into the sender-owned yring.
-3. Flush the producer.
-4. Mark the lane ready.
+2. With `Coordinated`, acquire the lane's active bit unless it is closed.
+3. Push into the sender-owned yring and flush the producer.
+4. With `Coordinated`, clear the active bit and perform deferred close cleanup.
+5. Mark the lane ready.
+
+`Deferred` is the default and omits steps 2 and 4. Policy dispatch is resolved
+through a sealed type parameter, not a runtime setting. Deferred lanes do not
+allocate the cleanup state or handoff mutex.
 
 ## Lane Readiness
 
@@ -187,6 +192,27 @@ MPSC receiver drop marks the channel closed and closes installed and pending
 consumers. MPMC closes the channel when its last receiver drops. Earlier MPMC
 receiver drops republish local work. Closing wakes blocked lane senders; later
 sends return `Disconnected`.
+
+With `Deferred`, closing a yring consumer leaves unread ring values owned by
+the surviving sender. Receiver-local staged values can drop earlier. Each
+lane releases retained values when its sender releases the ring.
+
+With `Coordinated`, each lane wraps its yring with an atomic active/closed state and a consumer
+handoff slot. Sends acquire the active bit before pushing and clear it after
+flushing. Closing first drains the consumer's current window, including any
+prefetched but unread values. It then installs the consumer in the handoff
+slot and sets the closed bit. If no send is active, the receiver takes the
+consumer back for a final drain. Otherwise, the active send takes the consumer
+and drains late publications when it finishes. New sends cannot acquire a
+closed lane. The initial drain retains slot credit so that closing a full lane
+cannot make an in-flight send succeed by freeing capacity.
+
+The handoff mutex is acquired before setting the closed bit. Senders only
+access it after observing that bit, so the handoff never waits for a paused
+sender. Payload destructors run outside the mutex. Unread values are
+destroyed while sender handles remain alive; an unfinished concurrent send
+may defer cleanup of its late publication until that send resumes. Ring
+allocations remain owned by their sender handles.
 
 ## Ordering And Capacity
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -230,3 +230,60 @@ cargo run --example fanring-chart -- \
   --run RUN_ID \
   --output /path/to/latency-mpsc.svg
 ```
+
+## Teardown policy comparisons
+
+`channel` uses Deferred. The comparison benches include a second monomorphized
+fanring implementation using Coordinated, identified as `fanring-coordinated`
+(MPSC) and `fanring-coordinated-mpmc` (MPMC). Both use the same harness and rotate
+measurement order with the other implementations. Their result files live in
+separate `fanring` and `fanring-coordinated` directories, so policies cannot be
+combined as samples of the same implementation. General chart generation labels
+both policies and can include both in detail and summary charts. Legacy summary
+runs containing only Deferred remain supported.
+
+The focused policy charts use `u64`, five samples per case, and all combinations
+of 1, 2, 4, and 8 workers. Run each command sequentially on an idle system. Build,
+format, and run Clippy before benchmarking; stop on any warning or timeout.
+
+```sh
+cargo fmt --all --check
+cargo build --locked
+cargo clippy --all-targets --all-features -- -D warnings
+cargo bench --locked --no-run --bench comparison --bench mpmc
+
+FANRING_BENCH_CACHE_DIR=target/teardown-policy-results \
+FANRING_BENCH_PAYLOADS=u64 \
+FANRING_BENCH_IMPLS=fanring,fanring-coordinated \
+FANRING_BENCH_PRODUCERS=1,2,4,8 \
+FANRING_BENCH_SAMPLES=5 FANRING_BENCH_SECS=1 \
+FANRING_BENCH_WARMUP_SECS=0.25 FANRING_BENCH_CAPACITY=8192 \
+FANRING_BENCH_MODE=try FANRING_BENCH_PROFILE=uncontrolled \
+FANRING_BENCH_AFFINITY=auto \
+cargo bench --locked --bench comparison
+
+FANRING_BENCH_CACHE_DIR=target/teardown-policy-results \
+FANRING_BENCH_PAYLOADS=u64 \
+FANRING_BENCH_IMPLS=fanring-mpmc,fanring-coordinated-mpmc \
+FANRING_BENCH_PRODUCERS=1,2,4,8 FANRING_BENCH_CONSUMERS=1,2,4,8 \
+FANRING_BENCH_SAMPLES=5 FANRING_BENCH_SECS=1 \
+FANRING_BENCH_WARMUP_SECS=0.25 FANRING_BENCH_CAPACITY=8192 \
+FANRING_BENCH_MODE=try FANRING_BENCH_PROFILE=uncontrolled \
+FANRING_BENCH_AFFINITY=auto \
+cargo bench --locked --bench mpmc
+
+cargo run --example fanring-chart -- \
+  --results-dir target/teardown-policy-results \
+  --output doc/charts/teardown-mpsc.svg
+cargo run --example fanring-chart -- --mpmc \
+  --results-dir target/teardown-policy-results \
+  --output doc/charts/teardown-mpmc.svg
+
+cargo run --locked --example teardown
+```
+
+The last command checks owned-payload destruction separately from throughput.
+It prints destructor counts before and after dropping senders for the dependency
+versions in `Cargo.lock`. These sequential observations do not establish a
+competitor's behavior during concurrent publication. See [the teardown comparison](doc/teardown.md)
+for the policy contract and upstream issue references.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Sender registration is dynamic. Each sender writes to its own ring, so
 producers do not contend on a shared queue tail. MPSC drains those rings
 directly; MPMC stages prefetched batches in stealable receiver-local queues.
 
+`Deferred` teardown is the default and avoids cleanup coordination on sends.
+Choose `Coordinated` to reclaim unread payloads independently of idle sender
+lifetimes.
+
 Requires Rust 1.93 or newer.
 
 | | Nonblocking | Blocking | Timeout | Deadline |
@@ -36,6 +40,34 @@ Detailed throughput heatmaps cover thread counts and payload sizes.
 #### MPMC wake latency
 
 ![MPMC wake-latency chart](https://raw.githubusercontent.com/paddor/fanring.rs/main/doc/charts/latency-mpmc.svg)
+
+## Teardown policies
+
+`Deferred` is the default teardown policy: unread ring payloads may remain
+alive until their sender drops. Choose `Coordinated` when queued replies,
+permits, or buffers must be released independently of idle sender lifetimes:
+
+```rust
+use fanring::{mpsc, teardown::Coordinated};
+let (tx, rx) = mpsc::channel_with_policy::<String, Coordinated>(256);
+```
+
+The policy is part of the endpoint types and inherited by cloned handles.
+`Coordinated` teardown drains unread values; overlapping sends clean up late
+publications when they resume. Receiver drop does not wait for paused producers.
+The additional send coordination has a measurable cost:
+
+![MPSC teardown policy throughput](https://raw.githubusercontent.com/paddor/fanring.rs/main/doc/charts/teardown-mpsc.svg)
+
+![MPMC teardown policy throughput](https://raw.githubusercontent.com/paddor/fanring.rs/main/doc/charts/teardown-mpmc.svg)
+
+The general comparison and wake-latency charts above use `Deferred` for fanring.
+These policy charts compare `u64` traffic under both policies on the same system.
+See [teardown contracts, reproduction, and observed behavior in other channels](doc/teardown.md).
+The pinned bounded Crossbeam, Crossfire, Flume, Kanal, and Thingbuf versions all
+retain unread payloads in our receiver-drop probe while senders remain alive.
+This is a payload-lifetime distinction; successful send still does not guarantee
+that application code processes the message.
 
 ## MPSC
 
@@ -97,8 +129,9 @@ flight.
   receiver staging can temporarily exceed sender-ring capacity.
 - Nonblocking, blocking, timeout, and deadline operations are available.
   Blocking operations spin briefly before parking.
-- Disconnection never discards buffered values. MPMC `Empty` may be transient
-  while receivers move internal work; `Disconnected` is final.
+- Dropping the last sender preserves buffered values for receivers to drain.
+  Last-receiver drop follows the chosen teardown policy. MPMC `Empty` may be
+  transient while receivers move internal work; `Disconnected` is final.
 - Sender hot paths and MPSC batching avoid a shared queue lock. MPMC work
   distribution and topology maintenance use mutexes; blocking operations may
   park.

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -235,7 +235,13 @@ fn run_payload<T>(
 
     let mut implementations: Vec<(&str, BenchFn<T>)> = Vec::new();
     if impl_filter.matches("fanring") {
-        implementations.push(("fanring", bench_fanring::<T>));
+        implementations.push(("fanring", bench_fanring::<T, fanring::teardown::Deferred>));
+    }
+    if impl_filter.matches("fanring-coordinated") {
+        implementations.push((
+            "fanring-coordinated",
+            bench_fanring::<T, fanring::teardown::Coordinated>,
+        ));
     }
     if impl_filter.matches("crossbeam-channel") {
         implementations.push(("crossbeam-channel", bench_crossbeam_channel::<T>));
@@ -312,17 +318,34 @@ fn run_payload<T>(
     }
 }
 
-fn bench_fanring<T>(context: &RunContext, config: Config, mode: Mode, payload: Payload<T>) -> Row
+fn bench_fanring<T, P: fanring::teardown::Teardown>(
+    context: &RunContext,
+    config: Config,
+    mode: Mode,
+    payload: Payload<T>,
+) -> Row
 where
     T: Copy + Send + 'static,
 {
-    let (tx0, rx) = fanring::mpsc::channel::<T>(config.capacity_per_sender);
+    let (tx0, rx) = fanring::mpsc::channel_with_policy::<T, P>(config.capacity_per_sender);
     let mut senders = vec![tx0];
     for _ in 1..config.producers {
         let tx = senders[0].try_clone().expect("fanring sender slot");
         senders.push(tx);
     }
-    run_channel(context, "fanring", config, mode, payload, senders, rx)
+    run_channel(
+        context,
+        if P::COORDINATED {
+            "fanring-coordinated"
+        } else {
+            "fanring"
+        },
+        config,
+        mode,
+        payload,
+        senders,
+        rx,
+    )
 }
 
 fn bench_crossbeam_channel<T>(
@@ -664,7 +687,9 @@ fn join_counts(handles: Vec<thread::JoinHandle<u64>>, implementation: &str) -> u
         .sum()
 }
 
-impl<T: Send + 'static> BenchSender<T> for fanring::mpsc::Sender<T> {
+impl<T: Send + 'static, P: fanring::teardown::Teardown> BenchSender<T>
+    for fanring::mpsc::Sender<T, P>
+{
     #[inline(always)]
     fn try_send(&mut self, value: T) -> SendAttempt {
         match self.try_send(value) {
@@ -680,7 +705,7 @@ impl<T: Send + 'static> BenchSender<T> for fanring::mpsc::Sender<T> {
     }
 }
 
-impl<T> BenchReceiver<T> for fanring::mpsc::Receiver<T> {
+impl<T, P: fanring::teardown::Teardown> BenchReceiver<T> for fanring::mpsc::Receiver<T, P> {
     #[inline(always)]
     fn try_recv(&mut self) -> RecvAttempt<T> {
         match self.try_recv() {
@@ -924,7 +949,7 @@ fn row<T>(
         producers: config.producers,
         capacity_per_sender: config.capacity_per_sender,
         nominal_capacity: config.total_capacity(),
-        capacity_model: if implementation == "fanring" {
+        capacity_model: if implementation.starts_with("fanring") {
             "per-ring-hwm"
         } else {
             "shared-bound"
@@ -1033,6 +1058,7 @@ fn selected_payload_count(filter: &Filter) -> usize {
 fn selected_implementation_count(filter: &Filter, mode: Mode) -> usize {
     [
         ("fanring", true),
+        ("fanring-coordinated", true),
         ("crossbeam-channel", true),
         ("crossfire", true),
         ("flume", true),

--- a/benches/mpmc.rs
+++ b/benches/mpmc.rs
@@ -238,7 +238,16 @@ fn run_payload<T>(
 
     let mut implementations: Vec<(&str, BenchFn<T>)> = Vec::new();
     if impl_filter.matches("fanring-mpmc") {
-        implementations.push(("fanring-mpmc", bench_fanring::<T>));
+        implementations.push((
+            "fanring-mpmc",
+            bench_fanring::<T, fanring::teardown::Deferred>,
+        ));
+    }
+    if impl_filter.matches("fanring-coordinated-mpmc") {
+        implementations.push((
+            "fanring-coordinated-mpmc",
+            bench_fanring::<T, fanring::teardown::Coordinated>,
+        ));
     }
     if impl_filter.matches("crossbeam-channel") {
         implementations.push(("crossbeam-channel", bench_crossbeam::<T>));
@@ -307,11 +316,16 @@ fn run_payload<T>(
     }
 }
 
-fn bench_fanring<T>(context: &RunContext, config: Config, mode: Mode, payload: Payload<T>) -> Row
+fn bench_fanring<T, P: fanring::teardown::Teardown>(
+    context: &RunContext,
+    config: Config,
+    mode: Mode,
+    payload: Payload<T>,
+) -> Row
 where
     T: Copy + Send + 'static,
 {
-    let (tx0, rx0) = fanring::mpmc::channel(config.capacity_per_sender);
+    let (tx0, rx0) = fanring::mpmc::channel_with_policy::<T, P>(config.capacity_per_sender);
     let mut senders = vec![tx0];
     for _ in 1..config.producers {
         senders.push(senders[0].try_clone().expect("fanring sender lane"));
@@ -322,7 +336,11 @@ where
     }
     run_channel(
         context,
-        "fanring-mpmc",
+        if P::COORDINATED {
+            "fanring-coordinated-mpmc"
+        } else {
+            "fanring-mpmc"
+        },
         config,
         mode,
         payload,
@@ -693,7 +711,7 @@ fn row<T>(
         consumers: config.consumers,
         capacity_per_sender: config.capacity_per_sender,
         nominal_capacity: config.total_capacity(),
-        capacity_model: if implementation == "fanring-mpmc" {
+        capacity_model: if implementation.starts_with("fanring") {
             "per-ring-hwm-with-staging"
         } else {
             "shared-bound"
@@ -710,7 +728,7 @@ fn row<T>(
     }
 }
 
-impl<T> BenchSender<T> for fanring::mpmc::Sender<T>
+impl<T, P: fanring::teardown::Teardown> BenchSender<T> for fanring::mpmc::Sender<T, P>
 where
     T: Send + 'static,
 {
@@ -729,7 +747,7 @@ where
     }
 }
 
-impl<T> BenchReceiver<T> for fanring::mpmc::Receiver<T>
+impl<T, P: fanring::teardown::Teardown> BenchReceiver<T> for fanring::mpmc::Receiver<T, P>
 where
     T: Send + 'static,
 {
@@ -984,6 +1002,7 @@ fn selected_payload_count(filter: &Filter) -> usize {
 fn selected_implementation_count(filter: &Filter) -> usize {
     [
         "fanring-mpmc",
+        "fanring-coordinated-mpmc",
         "crossbeam-channel",
         "crossfire-mpmc",
         "flume",

--- a/doc/charts/teardown-mpmc.svg
+++ b/doc/charts/teardown-mpmc.svg
@@ -1,0 +1,331 @@
+<svg width="1440" height="240" viewBox="0 0 1440 240" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="1440" height="240" opacity="1" fill="#000000" stroke="none"/>
+<text x="720" y="17" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="12.096774193548388" opacity="1" fill="#E5E7EB">
+fanring MPMC throughput comparison
+</text>
+<text x="720" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; all workers pinned, physical cores first; try operations; 5 samples; nominal capacity 8192 items; natural queue occupancy
+</text>
+<text x="720" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+u64 (8 B); median M items/s (+/- MAD); color scale 0-150; white outline = winner
+</text>
+<text x="172" y="97" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+producer threads
+</text>
+<text x="172" y="119" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+consumer threads
+</text>
+<text x="28" y="136" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+implementation
+</text>
+<text x="334" y="97" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="221" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="296" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="371" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="446" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="642" y="97" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="529" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="604" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="679" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="754" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="950" y="97" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="837" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="912" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="987" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="1062" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="1258" y="97" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="1145" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="1220" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="1295" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="1370" y="119" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="28" y="161" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
+fanring Deferred
+</text>
+<rect x="186" y="149" width="71" height="25" opacity="1" fill="#385B89" stroke="none"/>
+<rect x="186" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="221" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+66.1
+</text>
+<text x="221" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="#34537D" stroke="none"/>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+57.5
+</text>
+<text x="296" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="336" y="149" width="71" height="25" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="336" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="371" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+68.5
+</text>
+<text x="371" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.4%
+</text>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="#283E5E" stroke="none"/>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="446" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+34.1
+</text>
+<text x="446" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-14.2%
+</text>
+<rect x="494" y="149" width="71" height="25" opacity="1" fill="#385B89" stroke="none"/>
+<text x="529" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+66.0
+</text>
+<text x="529" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="569" y="149" width="71" height="25" opacity="1" fill="#355683" stroke="none"/>
+<rect x="569" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="604" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+61.3
+</text>
+<text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.1%
+</text>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4E83C7" stroke="none"/>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+112.1
+</text>
+<text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.3%
+</text>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="#3D6498" stroke="none"/>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+77.2
+</text>
+<text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.2%
+</text>
+<rect x="802" y="149" width="71" height="25" opacity="1" fill="#385A88" stroke="none"/>
+<rect x="802" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="837" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+65.6
+</text>
+<text x="837" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="877" y="149" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<rect x="877" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="912" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+61.0
+</text>
+<text x="912" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4572AD" stroke="none"/>
+<text x="987" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+93.0
+</text>
+<text x="987" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5693DE" stroke="none"/>
+<rect x="1027" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1062" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+129.4
+</text>
+<text x="1062" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-7.9%
+</text>
+<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
+<rect x="1110" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1145" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+30.3
+</text>
+<text x="1145" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#294060" stroke="none"/>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1220" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+35.7
+</text>
+<text x="1220" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.7%
+</text>
+<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
+<text x="1295" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64.8
+</text>
+<text x="1295" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.5%
+</text>
+<rect x="1335" y="149" width="71" height="25" opacity="1" fill="#5B9BEB" stroke="none"/>
+<rect x="1335" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1370" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+138.9
+</text>
+<text x="1370" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.9%
+</text>
+<text x="28" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
+fanring Coordinated
+</text>
+<rect x="186" y="178" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<text x="221" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+18.1
+</text>
+<text x="221" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-16.2%
+</text>
+<rect x="261" y="178" width="71" height="25" opacity="1" fill="#21324B" stroke="none"/>
+<text x="296" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.7
+</text>
+<text x="296" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.9%
+</text>
+<rect x="336" y="178" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
+<text x="371" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+17.8
+</text>
+<text x="371" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.3%
+</text>
+<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<text x="446" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+11.9
+</text>
+<text x="446" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="494" y="178" width="71" height="25" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="494" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="529" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+68.4
+</text>
+<text x="529" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-1.1%
+</text>
+<rect x="569" y="178" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<text x="604" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+61.1
+</text>
+<text x="604" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="644" y="178" width="71" height="25" opacity="1" fill="#2C4568" stroke="none"/>
+<text x="679" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+41.8
+</text>
+<text x="679" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.7%
+</text>
+<rect x="719" y="178" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<text x="754" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+20.6
+</text>
+<text x="754" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-10.9%
+</text>
+<rect x="802" y="178" width="71" height="25" opacity="1" fill="#375A88" stroke="none"/>
+<text x="837" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+65.5
+</text>
+<text x="837" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="877" y="178" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<text x="912" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+60.8
+</text>
+<text x="912" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="952" y="178" width="71" height="25" opacity="1" fill="#4675B2" stroke="none"/>
+<rect x="952" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="987" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+96.2
+</text>
+<text x="987" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.5%
+</text>
+<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
+<text x="1062" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64.6
+</text>
+<text x="1062" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.9%
+</text>
+<rect x="1110" y="178" width="71" height="25" opacity="1" fill="#263B58" stroke="none"/>
+<text x="1145" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+29.9
+</text>
+<text x="1145" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#293F60" stroke="none"/>
+<text x="1220" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+35.5
+</text>
+<text x="1220" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.6%
+</text>
+<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#395D8D" stroke="none"/>
+<rect x="1260" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1295" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+69.2
+</text>
+<text x="1295" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-3.9%
+</text>
+<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#4E83C7" stroke="none"/>
+<text x="1370" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+111.9
+</text>
+<text x="1370" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.5%
+</text>
+<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,240 1416,240 "/>
+<text x="720" y="231" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">
+Deferred retains unread ring payloads; Coordinated reclaims them during close or an overlapping send. Capacity: per-ring HWM plus receiver staging
+</text>
+</svg>

--- a/doc/charts/teardown-mpsc.svg
+++ b/doc/charts/teardown-mpsc.svg
@@ -1,0 +1,100 @@
+<svg width="1024" height="210" viewBox="0 0 1024 210" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="1024" height="210" opacity="1" fill="#000000" stroke="none"/>
+<text x="512" y="17" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="12.096774193548388" opacity="1" fill="#E5E7EB">
+fanring MPSC throughput comparison
+</text>
+<text x="512" y="35" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#9CA3AF">
+Linux VM on a 2018 Mac Mini, 6 cores, performance governor, turbo off; all workers pinned, physical cores first; try operations; 5 samples; nominal capacity 8192 items; natural queue occupancy
+</text>
+<text x="512" y="73" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+u64 (8 B); median M items/s (+/- MAD); color scale 0-100; white outline = winner
+</text>
+<text x="28" y="104" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+implementation
+</text>
+<text x="592" y="96" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#9CA3AF">
+producer threads
+</text>
+<text x="286" y="114" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+1
+</text>
+<text x="490" y="114" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+2
+</text>
+<text x="694" y="114" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+4
+</text>
+<text x="898" y="114" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#E5E7EB">
+8
+</text>
+<text x="28" y="138" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
+fanring Deferred
+</text>
+<rect x="186" y="128" width="200" height="21" opacity="1" fill="#5189CF" stroke="none"/>
+<rect x="186" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="286" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+78.9
+</text>
+<text x="286" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-6.6%
+</text>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="#5B9CED" stroke="none"/>
+<rect x="390" y="128" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="490" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+93.3
+</text>
+<text x="490" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-1.5%
+</text>
+<rect x="594" y="128" width="200" height="21" opacity="1" fill="#5D9FF0" stroke="none"/>
+<text x="694" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+95.2
+</text>
+<text x="694" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.5%
+</text>
+<rect x="798" y="128" width="200" height="21" opacity="1" fill="#355580" stroke="none"/>
+<text x="898" y="134" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+39.8
+</text>
+<text x="898" y="145" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.4%
+</text>
+<text x="28" y="163" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
+fanring Coordinated
+</text>
+<rect x="186" y="153" width="200" height="21" opacity="1" fill="#294060" stroke="none"/>
+<text x="286" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+23.9
+</text>
+<text x="286" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<rect x="390" y="153" width="200" height="21" opacity="1" fill="#355682" stroke="none"/>
+<text x="490" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+40.7
+</text>
+<text x="490" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="594" y="153" width="200" height="21" opacity="1" fill="#5D9FF0" stroke="none"/>
+<rect x="594" y="153" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="694" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+95.3
+</text>
+<text x="694" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-2.0%
+</text>
+<rect x="798" y="153" width="200" height="21" opacity="1" fill="#385C8A" stroke="none"/>
+<rect x="798" y="153" width="200" height="21" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="898" y="159" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+44.8
+</text>
+<text x="898" y="170" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.3%
+</text>
+<polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,210 1000,210 "/>
+<text x="512" y="201" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">
+Deferred retains unread ring payloads; Coordinated reclaims them during close or an overlapping send. Capacity: per-ring HWM
+</text>
+</svg>

--- a/doc/teardown.md
+++ b/doc/teardown.md
@@ -1,0 +1,124 @@
+# Teardown policies
+
+Fanring lets each channel choose when unread payloads are destroyed. The policy
+is fixed at construction, included in the endpoint types, and inherited by
+every cloned sender, newly registered lane, and cloned MPMC receiver.
+
+| Policy | After the last receiver drops | Send cost |
+|---|---|---|
+| `Deferred` (default) | Unread ring values may remain until their sender releases the ring. Receiver-local staged values can drop earlier. | No cleanup ownership handshake. |
+| `Coordinated` | Receiver drains unread values. An overlapping send owns any remaining cleanup and destroys late publications when it resumes. | Atomic ownership handshake around push/flush. |
+
+Both policies disconnect senders and wake blocked sends. Neither requires the
+application to stop producers before dropping a receiver. With Coordinated,
+receiver teardown does not wait for a paused producer; cleanup of that
+producer's late publication can outlive receiver drop. User destructors run
+outside the cleanup mutex, on either the receiver or producer thread. A user
+destructor can itself block or panic. Ring allocations remain alive while their
+sender handles own them under either policy.
+
+Dropping a non-last MPMC receiver preserves its queued work for the remaining
+receivers under both policies. Dropping the last sender preserves buffered
+messages for receivers to drain under both policies.
+
+## Choosing a policy
+
+Deferred suits plain numeric values, disposable telemetry, and channels whose
+sender lifetimes already bound acceptable retention. Budget unread payloads
+per sender lane, including allocations they own. A bounded number of slots
+does not bound the bytes inside queued `Vec`s.
+
+Choose Coordinated for messages containing reply senders, permits, or other
+resources whose release must not depend on an idle sender being dropped:
+
+```rust
+use fanring::{mpsc, teardown::Coordinated};
+
+let (mut tx, rx) = mpsc::channel_with_policy::<_, Coordinated>(4);
+let (reply, response) = std::sync::mpsc::channel::<()>();
+tx.try_send(reply).unwrap();
+drop(rx);
+assert_eq!(response.try_recv(), Err(std::sync::mpsc::TryRecvError::Disconnected));
+drop(tx);
+```
+
+`mpmc::channel_with_policy` works the same way.
+`try_channel_with_policy` validates capacity without panicking. Existing
+`channel` and `try_channel` constructors select Deferred.
+
+A successful send accepts a message into the channel; it does not acknowledge
+application processing. Payload `Drop` is the cleanup mechanism under both
+policies. Adding a custom destructor cannot make a retained payload drop sooner.
+For example, a queued `oneshot::Sender` already has a cancellation destructor;
+its lifetime determines when that destructor can notify the waiting caller.
+
+## Measured throughput cost
+
+These policy comparisons use `u64`, nonblocking operations, uncontrolled queue
+occupancy, and an aggregate nominal ring capacity of 8192. Each cell shows the
+median of five one-second samples and relative median absolute deviation.
+Implementations alternate order between samples. They measure steady traffic,
+including normal benchmark draining, rather than the latency of abandoning a
+backlog. Owned-payload destruction is checked separately below.
+
+![MPSC teardown policy throughput](charts/teardown-mpsc.svg)
+
+![MPMC teardown policy throughput](charts/teardown-mpmc.svg)
+
+The small-producer cases expose a substantial coordination cost. The charts
+make that choice visible instead of presenting different guarantees as the same
+operation. Reproduction commands are in [DEVELOPMENT.md](../DEVELOPMENT.md).
+
+## Other channels: observed payload retention
+
+Checked on 2026-09-08 with the versions pinned in this repository's `Cargo.lock`.
+The probe queues four owned payloads, drops every receiver while keeping the
+sender alive, checks destructor counts, then drops the sender. All four values
+are destroyed exactly once after both endpoints are gone in every case.
+
+| Channel/version | Values destroyed at receiver drop, sender alive |
+|---|---:|
+| fanring MPSC/MPMC Deferred | 0/4 |
+| fanring MPSC/MPMC Coordinated | 4/4 |
+| crossbeam-channel 0.5.16 bounded | 0/4 |
+| crossbeam-channel 0.5.16 unbounded | 4/4 |
+| crossfire 3.1.19 MPSC/MPMC, bounded/unbounded | 0/4 |
+| flume 0.12.0, bounded/unbounded | 0/4 |
+| kanal 0.1.1, bounded/unbounded | 0/4 |
+| thingbuf 0.1.6 blocking MPSC | 0/4 |
+| yring 0.3.16 SPSC | 0/4 |
+
+Run `cargo run --locked --example teardown` to reproduce the table. These are
+sequential observations, not promises about other libraries' APIs or concurrent
+teardown progress. Retention is memory-safe, but can strand replies or permits
+when their owners remain queued behind a surviving sender. `concurrent-queue`
+is a standalone queue without receiver handles; its
+[`close()`](https://docs.rs/concurrent-queue/2.5.0/concurrent_queue/struct.ConcurrentQueue.html#method.close)
+preserves queued items for subsequent pops, so receiver-drop semantics do not apply.
+The probe also checks it through two `Arc` owners: close the queue and drop one
+owner, then drop the remaining owner.
+
+| Queue/version | Values destroyed after close, one owner still alive | After last owner drops |
+|---|---:|---:|
+| concurrent-queue 2.5.0 bounded | 0/4 | 4/4 |
+| concurrent-queue 2.5.0 unbounded | 0/4 | 4/4 |
+
+Unlike a channel receiver drop, dropping one `Arc` alone does not close this
+queue or prevent its remaining owners from pushing or popping.
+
+Crossbeam has an exact request/reply deadlock report in
+[#1102](https://github.com/crossbeam-rs/crossbeam/issues/1102). Its
+[fix #1121](https://github.com/crossbeam-rs/crossbeam/pull/1121) merged on
+2026-06-07, but is absent from released 0.5.17 and listed for 0.5.18 in the
+[next-release preparation](https://github.com/crossbeam-rs/crossbeam/pull/1162).
+That implementation waits for reserved slots to finish publishing during
+receiver teardown. Crossbeam's existing unbounded cleanup also waits for
+unfinished writes. Fanring Coordinated instead hands late cleanup to the
+producer, allowing the receiver to finish without waiting for that producer.
+
+Crossfire's [`send` documentation](https://docs.rs/crossfire/3.1.19/crossfire/struct.AsyncTx.html#method.send)
+recommends payload `Drop` for sends accepted during receiver destruction, but
+does not promise prompt destruction. No matching payload-retention issue was
+found in its open/closed issues during this review;
+[#15](https://github.com/frostyplanet/crossfire-rs/issues/15) concerns detecting
+receiver disconnection rather than releasing queued payloads.

--- a/examples/teardown.rs
+++ b/examples/teardown.rs
@@ -1,0 +1,137 @@
+//! Sequential payload-lifetime probe for the versions pinned in Cargo.lock.
+//! This checks destruction timing, not concurrent teardown progress guarantees.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone, Debug, Default)]
+struct Payload(Option<Arc<AtomicUsize>>);
+
+impl Drop for Payload {
+    fn drop(&mut self) {
+        if let Some(drops) = &self.0 {
+            drops.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+const QUEUED: usize = 4;
+
+fn probe<S, R>(name: &str, build: impl FnOnce(Payload) -> (S, R)) {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let (sender, receiver) = build(Payload(Some(drops.clone())));
+    assert_eq!(
+        drops.load(Ordering::Relaxed),
+        0,
+        "{name}: unexpected early drop"
+    );
+    drop(receiver);
+    let at_receiver_drop = drops.load(Ordering::Relaxed);
+    drop(sender);
+    let at_sender_drop = drops.load(Ordering::Relaxed);
+    assert_eq!(at_sender_drop, QUEUED, "{name}: exactly-once destruction");
+    println!("| {name} | {at_receiver_drop}/{QUEUED} | {at_sender_drop}/{QUEUED} |");
+}
+
+macro_rules! channel_probe {
+    ($name:expr, $channel:expr) => {
+        probe($name, |payload| {
+            #[allow(unused_mut)]
+            let (mut tx, rx) = $channel;
+            for _ in 1..QUEUED {
+                tx.try_send(payload.clone()).unwrap();
+            }
+            tx.try_send(payload).unwrap();
+            (tx, rx)
+        });
+    };
+}
+
+fn queue_probe(name: &str, queue: concurrent_queue::ConcurrentQueue<Payload>) {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let queue = Arc::new(queue);
+    for _ in 0..QUEUED {
+        queue.push(Payload(Some(drops.clone()))).unwrap();
+    }
+    let remaining_owner = queue.clone();
+    queue.close();
+    drop(queue);
+    let at_close = drops.load(Ordering::Relaxed);
+    drop(remaining_owner);
+    let at_last_owner_drop = drops.load(Ordering::Relaxed);
+    assert_eq!(
+        at_last_owner_drop, QUEUED,
+        "{name}: exactly-once destruction"
+    );
+    println!("| {name} | {at_close}/{QUEUED} | {at_last_owner_drop}/{QUEUED} |");
+}
+
+fn main() {
+    println!("| Channel | Destroyed after last receiver drop, sender alive | After sender drop |");
+    println!("|---|---:|---:|");
+    channel_probe!("fanring MPSC Deferred", fanring::mpsc::channel(QUEUED));
+    channel_probe!("fanring MPMC Deferred", fanring::mpmc::channel(QUEUED));
+    channel_probe!(
+        "fanring MPSC Coordinated",
+        fanring::mpsc::channel_with_policy::<_, fanring::teardown::Coordinated>(QUEUED)
+    );
+    channel_probe!(
+        "fanring MPMC Coordinated",
+        fanring::mpmc::channel_with_policy::<_, fanring::teardown::Coordinated>(QUEUED)
+    );
+    channel_probe!(
+        "crossbeam-channel bounded",
+        crossbeam_channel::bounded(QUEUED)
+    );
+    channel_probe!(
+        "crossbeam-channel unbounded",
+        crossbeam_channel::unbounded()
+    );
+    channel_probe!(
+        "crossfire MPSC bounded",
+        crossfire::mpsc::bounded_blocking(QUEUED)
+    );
+    channel_probe!(
+        "crossfire MPMC bounded",
+        crossfire::mpmc::bounded_blocking(QUEUED)
+    );
+    channel_probe!(
+        "crossfire MPSC unbounded",
+        crossfire::mpsc::unbounded_blocking()
+    );
+    channel_probe!(
+        "crossfire MPMC unbounded",
+        crossfire::mpmc::unbounded_blocking()
+    );
+    channel_probe!("flume bounded", flume::bounded(QUEUED));
+    channel_probe!("flume unbounded", flume::unbounded());
+    channel_probe!("kanal bounded", kanal::bounded(QUEUED));
+    channel_probe!("kanal unbounded", kanal::unbounded());
+    channel_probe!(
+        "thingbuf blocking",
+        thingbuf::mpsc::blocking::channel(QUEUED)
+    );
+    probe("yring SPSC", |payload| {
+        let (mut tx, rx) = yring::spsc(QUEUED);
+        for _ in 1..QUEUED {
+            tx.push(payload.clone()).unwrap();
+        }
+        tx.push(payload).unwrap();
+        tx.flush();
+        (tx, rx)
+    });
+
+    println!();
+    println!(
+        "| Queue | Destroyed after close and one Arc drop, another alive | After last Arc drop |"
+    );
+    println!("|---|---:|---:|");
+    queue_probe(
+        "concurrent-queue bounded",
+        concurrent_queue::ConcurrentQueue::bounded(QUEUED),
+    );
+    queue_probe(
+        "concurrent-queue unbounded",
+        concurrent_queue::ConcurrentQueue::unbounded(),
+    );
+}

--- a/src/bin/chart.rs
+++ b/src/bin/chart.rs
@@ -34,8 +34,10 @@ const DEFAULT_CHART_MODE: &str = "try";
 type ChartResult<T> = Result<T, ChartError>;
 
 const SERIES: &[(&str, &str)] = &[
-    ("fanring", "fanring"),
-    ("fanring-mpmc", "fanring"),
+    ("fanring", "fanring Deferred"),
+    ("fanring-coordinated", "fanring Coordinated"),
+    ("fanring-mpmc", "fanring Deferred"),
+    ("fanring-coordinated-mpmc", "fanring Coordinated"),
     ("crossbeam-channel", "crossbeam-channel 0.5.16"),
     ("crossfire", "crossfire 3.1.19"),
     ("crossfire-mpmc", "crossfire 3.1.19"),

--- a/src/bin/chart/render.rs
+++ b/src/bin/chart/render.rs
@@ -27,7 +27,10 @@ pub(super) fn draw_chart(rows: &[Row], output: &Path) -> ChartResult<()> {
     let payloads: Vec<String> = payloads.into_iter().map(|(payload, _)| payload).collect();
     let is_mpmc = rows.iter().any(|row| row.consumers.is_some());
     let width: u32 = if is_mpmc { 1440 } else { 1024 };
-    let section_h: u32 = if is_mpmc { 236 } else { 261 };
+    let series_count = present_series(&rows.iter().collect::<Vec<_>>()).len();
+    let (section_header, row_height) = if is_mpmc { (100, 29) } else { (78, 25) };
+    let section_h: u32 =
+        section_header + row_height * u32::try_from(series_count).expect("series count fits u32");
     let header_h: u32 = 58;
     let footer_h: u32 = 24;
     let payload_count = u32::try_from(payloads.len()).expect("payload count fits u32");
@@ -155,7 +158,7 @@ fn draw_mpsc_heatmap(
 
     for (row_index, (key, label)) in series.iter().enumerate() {
         let row_y = rows_top + usize_to_i32(row_index) * row_height;
-        let color = if label == &"fanring" {
+        let color = if key.starts_with("fanring") {
             RGBColor(250, 204, 21)
         } else {
             TEXT_COLOR
@@ -270,7 +273,7 @@ fn draw_mpmc_heatmap(
 
     for (row_index, (key, label)) in series.iter().enumerate() {
         let row_y = rows_top + usize_to_i32(row_index) * row_height;
-        let color = if label == &"fanring" {
+        let color = if key.starts_with("fanring") {
             RGBColor(250, 204, 21)
         } else {
             TEXT_COLOR
@@ -529,6 +532,19 @@ fn capacity_footnote(rows: &[Row], is_mpmc: bool) -> String {
         .collect::<BTreeSet<_>>();
     if models.is_empty() {
         return "Legacy results: capacity model was not recorded".to_string();
+    }
+    if rows
+        .iter()
+        .all(|row| row.implementation.starts_with("fanring"))
+    {
+        return format!(
+            "Deferred retains unread ring payloads; Coordinated reclaims them during close or an overlapping send. Capacity: per-ring HWM{}",
+            if is_mpmc {
+                " plus receiver staging"
+            } else {
+                ""
+            }
+        );
     }
     if is_mpmc {
         "Capacity: fanring uses per-ring HWM plus receiver staging; others use one shared bound"

--- a/src/bin/chart/summary.rs
+++ b/src/bin/chart/summary.rs
@@ -20,8 +20,14 @@ const SERIES: &[Series] = &[
     Series {
         mpsc_key: "fanring",
         mpmc_key: Some("fanring-mpmc"),
-        label: "fanring",
+        label: "fanring Deferred",
         color: RGBColor(0xf8, 0x71, 0x71),
+    },
+    Series {
+        mpsc_key: "fanring-coordinated",
+        mpmc_key: Some("fanring-coordinated-mpmc"),
+        label: "fanring Coordinated",
+        color: RGBColor(0xfb, 0xbf, 0x24),
     },
     Series {
         mpsc_key: "crossbeam-channel",
@@ -84,11 +90,17 @@ pub(super) fn draw_summary_chart(
             summary_values(mpmc_rows, true),
         ),
     ];
+    let coordinated = groups[0].1.contains_key("fanring Coordinated");
+    let expected_mpsc_series = SERIES.len() - usize::from(!coordinated);
     let expected_mpmc_series = SERIES
         .iter()
         .filter(|series| series.mpmc_key.is_some())
-        .count();
-    if groups[0].1.len() != SERIES.len() || groups[1].1.len() != expected_mpmc_series {
+        .count()
+        - usize::from(!coordinated);
+    if coordinated != groups[1].1.contains_key("fanring Coordinated")
+        || groups[0].1.len() != expected_mpsc_series
+        || groups[1].1.len() != expected_mpmc_series
+    {
         return Err(ChartError::NoRenderableRows);
     }
 
@@ -166,7 +178,13 @@ pub(super) fn draw_summary_chart(
         )?;
     }
 
-    draw_legend(&area, 65.0, plot_bottom + 52.0, nominal_capacity)?;
+    draw_legend(
+        &area,
+        65.0,
+        plot_bottom + 52.0,
+        nominal_capacity,
+        coordinated,
+    )?;
 
     area.present().chart()?;
     drop(area);
@@ -388,8 +406,18 @@ fn chart_header(
     Ok(())
 }
 
-fn draw_legend(area: &Area<'_>, x: f64, y: f64, nominal_capacity: usize) -> ChartResult<()> {
-    for (index, series) in SERIES.iter().enumerate() {
+fn draw_legend(
+    area: &Area<'_>,
+    x: f64,
+    y: f64,
+    nominal_capacity: usize,
+    coordinated: bool,
+) -> ChartResult<()> {
+    for (index, series) in SERIES
+        .iter()
+        .filter(|series| coordinated || series.mpsc_key != "fanring-coordinated")
+        .enumerate()
+    {
         let column = index % 3;
         let row = index / 3;
         let legend_x = x + column as f64 * 230.0;
@@ -404,8 +432,8 @@ fn draw_legend(area: &Area<'_>, x: f64, y: f64, nominal_capacity: usize) -> Char
         )?;
         text(
             area,
-            if series.mpsc_key == "fanring" {
-                format!("fanring (4 x {}-item rings)", nominal_capacity / 4)
+            if series.mpsc_key.starts_with("fanring") {
+                format!("{} (4 x {})", series.label, nominal_capacity / 4)
             } else {
                 series.label.to_string()
             },

--- a/src/bin/chart/support.rs
+++ b/src/bin/chart/support.rs
@@ -72,7 +72,10 @@ mod tests {
         let unknown = row("new-channel", 0, 1);
         assert_eq!(
             present_series(&[&known, &unknown]),
-            vec![("fanring", "fanring"), ("new-channel", "new-channel")]
+            vec![
+                ("fanring", "fanring Deferred"),
+                ("new-channel", "new-channel")
+            ]
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,15 @@
 //! Both variants provide nonblocking, blocking, timeout, and deadline APIs.
 //! Capacity is a high-water mark per sender, not one shared channel bound.
 //!
+//! # Teardown
+//!
+//! Constructors default to [`teardown::Deferred`]: unread ring payloads may
+//! remain alive until their sender drops. Choose [`teardown::Coordinated`] with
+//! [`mpsc::channel_with_policy`] or [`mpmc::channel_with_policy`] to reclaim
+//! payloads independently of idle sender lifetimes. An overlapping send can
+//! finish cleanup after receiver drop returns, without blocking that drop on a
+//! paused producer. The choice is per channel and inherited by cloned handles.
+//!
 //! # Example
 //!
 //! ```
@@ -42,4 +51,6 @@ pub mod mpmc;
 pub mod mpsc;
 mod publication;
 mod ready;
+mod ring;
+pub mod teardown;
 mod wait;

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -4,6 +4,8 @@
 //! into bounded local queues whose work can be stolen in batches by competing
 //! receivers. Ordering is relaxed.
 
+use crate::teardown::{Deferred, Teardown};
+
 use std::fmt;
 
 use arc_swap::ArcSwap;
@@ -44,6 +46,9 @@ const PARK_SPINS: usize = 0;
 
 /// Create an MPMC channel with one bounded ring per sender.
 ///
+/// Uses [`Deferred`] teardown. See [`channel_with_policy`] to opt into
+/// cleanup independent of idle sender lifetimes.
+///
 /// `capacity_per_sender` must be between 1 and [`MAX_CAPACITY_PER_SENDER`] and is
 /// rounded up by `yring` to the next power of two.
 ///
@@ -65,12 +70,57 @@ pub fn channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
 pub fn try_channel<T>(
     capacity_per_sender: usize,
 ) -> Result<(Sender<T>, Receiver<T>), ChannelError> {
+    try_channel_with_policy::<T, Deferred>(capacity_per_sender)
+}
+
+/// Create a channel with an explicit teardown policy.
+///
+/// [`Deferred`] is the default used by [`channel`].
+/// [`Coordinated`](crate::teardown::Coordinated) destroys unread payloads while
+/// sender handles remain alive; an overlapping send may finish cleanup later.
+/// The policy is inherited by all cloned handles.
+///
+/// # Panics
+///
+/// Panics when capacity is zero or exceeds [`MAX_CAPACITY_PER_SENDER`].
+///
+/// # Example
+///
+/// ```
+/// use fanring::{mpmc, teardown::Coordinated};
+/// let (mut tx, rx) = mpmc::channel_with_policy::<_, Coordinated>(4);
+/// let (reply, response) = std::sync::mpsc::channel::<()>();
+/// tx.try_send(reply).unwrap();
+/// drop(rx);
+/// assert_eq!(response.try_recv(), Err(std::sync::mpsc::TryRecvError::Disconnected));
+/// drop(tx);
+/// ```
+#[must_use]
+pub fn channel_with_policy<T, P: Teardown>(
+    capacity_per_sender: usize,
+) -> (Sender<T, P>, Receiver<T, P>) {
+    try_channel_with_policy(capacity_per_sender).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Fallible version of [`channel_with_policy`].
+///
+/// # Errors
+///
+/// Returns [`ChannelError`] when capacity is zero or exceeds
+/// [`MAX_CAPACITY_PER_SENDER`].
+#[allow(
+    clippy::type_complexity,
+    reason = "channel constructor returns its two endpoints"
+)]
+pub fn try_channel_with_policy<T, P: Teardown>(
+    capacity_per_sender: usize,
+) -> Result<(Sender<T, P>, Receiver<T, P>), ChannelError> {
     validate_capacity(capacity_per_sender, MAX_CAPACITY_PER_SENDER)?;
     Ok(build_channel(capacity_per_sender))
 }
 
-fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
-    let (producer, consumer) = yring::spsc(capacity_per_sender);
+fn build_channel<T, P: Teardown>(capacity_per_sender: usize) -> (Sender<T, P>, Receiver<T, P>) {
+    let (producer, consumer) = crate::ring::spsc(capacity_per_sender);
     let group = Arc::new(ReadyGroup::new(0));
     let work_group = Arc::new(ReadyGroup::new(0));
     let page = Arc::new(ReadyPage::new(0, group.clone()));
@@ -128,13 +178,13 @@ fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
     )
 }
 
-struct Shared<T> {
-    registry: Mutex<Registry<T>>,
+struct Shared<T, P: Teardown> {
+    registry: Mutex<Registry<T, P>>,
     #[cfg(not(loom))]
     work_queues: ArcSwap<Vec<(usize, WorkQueue<T>)>>,
     #[cfg(loom)]
     work_queues: Mutex<Vec<(usize, WorkQueue<T>)>>,
-    ready: ArcSwap<ReadyTopology<T>>,
+    ready: ArcSwap<ReadyTopology<T, P>>,
     ready_generation: AtomicUsize,
     orphaned_work: WorkQueue<T>,
     publications: PublicationTracker,
@@ -146,11 +196,15 @@ struct Shared<T> {
     capacity_per_sender: usize,
 }
 
-impl<T> Shared<T> {
+impl<T, P: Teardown> Shared<T, P> {
     #[allow(clippy::significant_drop_tightening)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "registration returns the lane key, readiness signal, and producer"
+    )]
     fn register_sender(
         &self,
-    ) -> Result<(LaneKey, Arc<LaneSignal>, yring::Producer<T>), TryRegisterError> {
+    ) -> Result<(LaneKey, Arc<LaneSignal>, crate::ring::Producer<T, P>), TryRegisterError> {
         if !self.receiver_alive.load(Ordering::Acquire) {
             return Err(TryRegisterError::Disconnected);
         }
@@ -162,7 +216,7 @@ impl<T> Shared<T> {
 
         let (key, page, topology_changed) = registry.allocate_lane();
         let signal = Arc::new(LaneSignal::new(page, key.slot));
-        let (producer, consumer) = yring::spsc(self.capacity_per_sender);
+        let (producer, consumer) = crate::ring::spsc(self.capacity_per_sender);
         registry.install_lane(LaneToken::new(Lane::new(key, signal.clone(), consumer)));
         if topology_changed {
             self.ready
@@ -206,7 +260,7 @@ impl<T> Shared<T> {
         self.publications.notify_change();
     }
 
-    fn ready_snapshot(&self) -> (std::sync::Arc<ReadyTopology<T>>, usize) {
+    fn ready_snapshot(&self) -> (std::sync::Arc<ReadyTopology<T, P>>, usize) {
         loop {
             let generation = self.ready_generation.load(Ordering::Acquire);
             let ready = self.ready.load_full();
@@ -221,11 +275,11 @@ impl<T> Shared<T> {
         signal.mark()
     }
 
-    fn activate_page(&self, page_id: usize) -> Option<LaneToken<T>> {
+    fn activate_page(&self, page_id: usize) -> Option<LaneToken<T, P>> {
         lock(&self.registry).take_ready_lane(page_id)
     }
 
-    fn finish_empty_lane(&self, mut lane: LaneToken<T>) -> FinishLane<T> {
+    fn finish_empty_lane(&self, mut lane: LaneToken<T, P>) -> FinishLane<T, P> {
         let mut registry = lock(&self.registry);
         lane.signal.finish_drain();
         lane.cached_available = lane.consumer.prefetch();
@@ -270,7 +324,7 @@ impl<T> Shared<T> {
     }
 }
 
-impl<T> fmt::Debug for Shared<T> {
+impl<T, P: Teardown> fmt::Debug for Shared<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Shared")
             .field(
@@ -297,19 +351,19 @@ struct LaneKey {
     generation: usize,
 }
 
-struct Slot<T> {
+struct Slot<T, P: Teardown> {
     generation: usize,
-    lane: Option<LaneToken<T>>,
+    lane: Option<LaneToken<T, P>>,
 }
 
-struct LanePage<T> {
+struct LanePage<T, P: Teardown> {
     ready: Arc<ReadyPage>,
     work_group: Arc<ReadyGroup>,
     work_bit: u64,
-    lanes: ConcurrentQueue<LaneToken<T>>,
+    lanes: ConcurrentQueue<LaneToken<T, P>>,
 }
 
-impl<T> LanePage<T> {
+impl<T, P: Teardown> LanePage<T, P> {
     fn new(ready: Arc<ReadyPage>, work_group: Arc<ReadyGroup>) -> Self {
         let work_bit = 1u64 << (ready.id() % PAGES_PER_GROUP);
         Self {
@@ -321,7 +375,7 @@ impl<T> LanePage<T> {
     }
 
     #[inline]
-    fn push(&self, lane: LaneToken<T>) {
+    fn push(&self, lane: LaneToken<T, P>) {
         self.lanes
             .push(lane)
             .unwrap_or_else(|_| unreachable!("one ready token exists per lane"));
@@ -333,7 +387,7 @@ impl<T> LanePage<T> {
     /// Re-publish before the pop so another receiver can claim a different
     /// queued lane without waiting for this receiver to finish its pop.
     #[inline]
-    fn pop_after_claim(&self) -> Option<LaneToken<T>> {
+    fn pop_after_claim(&self) -> Option<LaneToken<T, P>> {
         if !self.lanes.is_empty() {
             self.work_group.mark(self.work_bit);
         }
@@ -341,7 +395,7 @@ impl<T> LanePage<T> {
     }
 
     #[inline]
-    fn pop_direct(&self) -> Option<LaneToken<T>> {
+    fn pop_direct(&self) -> Option<LaneToken<T, P>> {
         self.lanes.pop().ok()
     }
 
@@ -351,27 +405,27 @@ impl<T> LanePage<T> {
     }
 }
 
-struct ReadyTopology<T> {
+struct ReadyTopology<T, P: Teardown> {
     ready_groups: Vec<Arc<ReadyGroup>>,
     work_groups: Vec<Arc<ReadyGroup>>,
-    pages: Vec<Arc<LanePage<T>>>,
+    pages: Vec<Arc<LanePage<T, P>>>,
 }
 
-struct Registry<T> {
-    slots: Vec<Slot<T>>,
+struct Registry<T, P: Teardown> {
+    slots: Vec<Slot<T, P>>,
     free: Vec<LaneKey>,
     groups: Vec<Arc<ReadyGroup>>,
     work_groups: Vec<Arc<ReadyGroup>>,
-    pages: Vec<Arc<LanePage<T>>>,
+    pages: Vec<Arc<LanePage<T, P>>>,
     work_queues: Vec<Option<WorkQueue<T>>>,
     free_receivers: Vec<usize>,
 }
 
-impl<T> Registry<T> {
+impl<T, P: Teardown> Registry<T, P> {
     fn new(
         group: Arc<ReadyGroup>,
         work_group: Arc<ReadyGroup>,
-        page: Arc<LanePage<T>>,
+        page: Arc<LanePage<T, P>>,
         work_queue: WorkQueue<T>,
     ) -> Self {
         Self {
@@ -450,14 +504,14 @@ impl<T> Registry<T> {
         )
     }
 
-    fn install_lane(&mut self, lane: LaneToken<T>) {
+    fn install_lane(&mut self, lane: LaneToken<T, P>) {
         let slot = &mut self.slots[lane.key.slot];
         debug_assert_eq!(slot.generation, lane.key.generation);
         debug_assert!(slot.lane.is_none());
         slot.lane = Some(lane);
     }
 
-    fn take_ready_lane(&mut self, page_id: usize) -> Option<LaneToken<T>> {
+    fn take_ready_lane(&mut self, page_id: usize) -> Option<LaneToken<T, P>> {
         let page = self.pages.get(page_id)?;
         let mut selected = None;
         let mut bits = page.ready.take();
@@ -484,7 +538,7 @@ impl<T> Registry<T> {
         selected
     }
 
-    fn clone_ready_topology(&self) -> ReadyTopology<T> {
+    fn clone_ready_topology(&self) -> ReadyTopology<T, P> {
         ReadyTopology {
             ready_groups: self.groups.clone(),
             work_groups: self.work_groups.clone(),
@@ -503,7 +557,7 @@ impl<T> Registry<T> {
         });
     }
 
-    fn take_all_lanes(&mut self) -> Vec<LaneToken<T>> {
+    fn take_all_lanes(&mut self) -> Vec<LaneToken<T, P>> {
         self.slots
             .iter_mut()
             .filter_map(|slot| slot.lane.take())

--- a/src/mpmc/receiver.rs
+++ b/src/mpmc/receiver.rs
@@ -1,3 +1,5 @@
+use crate::teardown::{Deferred, Teardown};
+
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::fmt;
@@ -16,14 +18,20 @@ use super::{
 /// Receiving half.
 ///
 /// Clones compete for messages through bounded stealable work queues.
-pub struct Receiver<T> {
-    pub(super) shared: Arc<Shared<T>>,
+///
+/// Dropping the last receiver disconnects senders. Unread payload destruction
+/// follows `P`: [`Deferred`] may retain ring values until their sender drops;
+/// [`Coordinated`](crate::teardown::Coordinated) reclaims them during teardown
+/// or when an overlapping send resumes. Other MPMC receivers preserve access
+/// to queued work until the last receiver drops.
+pub struct Receiver<T, P: Teardown = Deferred> {
+    pub(super) shared: Arc<Shared<T, P>>,
     pub(super) id: usize,
     pub(super) local: super::WorkQueue<T>,
     /// Unsynchronized staging used only while this is the sole receiver.
     pub(super) private: RefCell<VecDeque<T>>,
     pub(super) steal_cursor: usize,
-    pub(super) ready: RefCell<std::sync::Arc<ReadyTopology<T>>>,
+    pub(super) ready: RefCell<std::sync::Arc<ReadyTopology<T, P>>>,
     pub(super) seen_ready_generation: Cell<usize>,
     pub(super) ready_group_cursor: Cell<usize>,
     pub(super) ready_page_cursor: Cell<usize>,
@@ -32,7 +40,7 @@ pub struct Receiver<T> {
     pub(super) capacity_per_sender: usize,
 }
 
-impl<T> Clone for Receiver<T> {
+impl<T, P: Teardown> Clone for Receiver<T, P> {
     fn clone(&self) -> Self {
         // Make sole-receiver staging stealable before publishing another clone.
         let publication = self.shared.publications.begin();
@@ -57,7 +65,7 @@ impl<T> Clone for Receiver<T> {
     }
 }
 
-impl<T> Receiver<T> {
+impl<T, P: Teardown> Receiver<T, P> {
     /// Try to receive one value.
     ///
     /// # Errors
@@ -308,7 +316,7 @@ impl<T> Receiver<T> {
         }
     }
 
-    fn acquire_lane(&self) -> Option<(LaneToken<T>, Publication<'_>)> {
+    fn acquire_lane(&self) -> Option<(LaneToken<T, P>, Publication<'_>)> {
         self.refresh_ready_topology();
         let ready = self.ready.borrow();
         let prefer_work = self.prefer_work.replace(!self.prefer_work.get());
@@ -338,8 +346,8 @@ impl<T> Receiver<T> {
 
     fn acquire_work_lane<'a>(
         &'a self,
-        ready: &ReadyTopology<T>,
-    ) -> Option<(LaneToken<T>, Publication<'a>)> {
+        ready: &ReadyTopology<T, P>,
+    ) -> Option<(LaneToken<T, P>, Publication<'a>)> {
         let group_count = ready.work_groups.len();
         let start = self.ready_group_cursor.get() % group_count;
         let page_start = self.ready_page_cursor.get();
@@ -374,8 +382,8 @@ impl<T> Receiver<T> {
 
     fn acquire_ready_lane<'a>(
         &'a self,
-        ready: &ReadyTopology<T>,
-    ) -> Option<(LaneToken<T>, Publication<'a>)> {
+        ready: &ReadyTopology<T, P>,
+    ) -> Option<(LaneToken<T, P>, Publication<'a>)> {
         let group_count = ready.ready_groups.len();
         let start = self.ready_group_cursor.get() % group_count;
         let page_start = self.ready_page_cursor.get();
@@ -403,7 +411,7 @@ impl<T> Receiver<T> {
         None
     }
 
-    fn drain_lane(&self, mut lane: LaneToken<T>) -> LaneDrain<T> {
+    fn drain_lane(&self, mut lane: LaneToken<T, P>) -> LaneDrain<T> {
         if lane.cached_available == 0 {
             lane.cached_available = lane.consumer.prefetch();
             if lane.cached_available == 0 {
@@ -477,7 +485,7 @@ impl<T> Receiver<T> {
         }
     }
 
-    fn requeue_lane(&self, lane: LaneToken<T>) {
+    fn requeue_lane(&self, lane: LaneToken<T, P>) {
         let page_id = lane.key.slot / super::LANES_PER_PAGE;
         self.ready.borrow().pages[page_id].push(lane);
     }
@@ -546,19 +554,19 @@ impl<T> Receiver<T> {
     /// Iterate until every sender disconnects and buffered values are drained.
     #[inline]
     #[must_use]
-    pub const fn iter(&mut self) -> Iter<'_, T> {
+    pub const fn iter(&mut self) -> Iter<'_, T, P> {
         Iter { receiver: self }
     }
 
     /// Iterate over values immediately available without blocking.
     #[inline]
     #[must_use]
-    pub const fn try_iter(&mut self) -> TryIter<'_, T> {
+    pub const fn try_iter(&mut self) -> TryIter<'_, T, P> {
         TryIter { receiver: self }
     }
 }
 
-impl<T> Drop for Receiver<T> {
+impl<T, P: Teardown> Drop for Receiver<T, P> {
     fn drop(&mut self) {
         let publication = self.shared.publications.begin();
         let private = self.private.get_mut();
@@ -577,7 +585,7 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
-impl<T> fmt::Debug for Receiver<T> {
+impl<T, P: Teardown> fmt::Debug for Receiver<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver")
             .field("id", &self.id)
@@ -604,11 +612,11 @@ impl<T> fmt::Debug for Receiver<T> {
 
 /// Blocking iterator over a borrowed receiver.
 #[derive(Debug)]
-pub struct Iter<'a, T> {
-    receiver: &'a mut Receiver<T>,
+pub struct Iter<'a, T, P: Teardown = Deferred> {
+    receiver: &'a mut Receiver<T, P>,
 }
 
-impl<T> Iterator for Iter<'_, T> {
+impl<T, P: Teardown> Iterator for Iter<'_, T, P> {
     type Item = T;
 
     #[inline]
@@ -617,15 +625,15 @@ impl<T> Iterator for Iter<'_, T> {
     }
 }
 
-impl<T> std::iter::FusedIterator for Iter<'_, T> {}
+impl<T, P: Teardown> std::iter::FusedIterator for Iter<'_, T, P> {}
 
 /// Nonblocking iterator over a borrowed receiver.
 #[derive(Debug)]
-pub struct TryIter<'a, T> {
-    receiver: &'a mut Receiver<T>,
+pub struct TryIter<'a, T, P: Teardown = Deferred> {
+    receiver: &'a mut Receiver<T, P>,
 }
 
-impl<T> Iterator for TryIter<'_, T> {
+impl<T, P: Teardown> Iterator for TryIter<'_, T, P> {
     type Item = T;
 
     #[inline]
@@ -636,11 +644,11 @@ impl<T> Iterator for TryIter<'_, T> {
 
 /// Blocking iterator that owns its receiver.
 #[derive(Debug)]
-pub struct IntoIter<T> {
-    receiver: Receiver<T>,
+pub struct IntoIter<T, P: Teardown = Deferred> {
+    receiver: Receiver<T, P>,
 }
 
-impl<T> Iterator for IntoIter<T> {
+impl<T, P: Teardown> Iterator for IntoIter<T, P> {
     type Item = T;
 
     #[inline]
@@ -649,15 +657,15 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
-impl<T> std::iter::FusedIterator for IntoIter<T> {}
+impl<T, P: Teardown> std::iter::FusedIterator for IntoIter<T, P> {}
 
 #[allow(
     clippy::into_iter_without_iter,
     reason = "channel convention names the blocking iterator iter"
 )]
-impl<'a, T> IntoIterator for &'a mut Receiver<T> {
+impl<'a, T, P: Teardown> IntoIterator for &'a mut Receiver<T, P> {
     type Item = T;
-    type IntoIter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T, P>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -665,9 +673,9 @@ impl<'a, T> IntoIterator for &'a mut Receiver<T> {
     }
 }
 
-impl<T> IntoIterator for Receiver<T> {
+impl<T, P: Teardown> IntoIterator for Receiver<T, P> {
     type Item = T;
-    type IntoIter = IntoIter<T>;
+    type IntoIter = IntoIter<T, P>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -675,42 +683,42 @@ impl<T> IntoIterator for Receiver<T> {
     }
 }
 
-pub(super) struct Lane<T> {
+pub(super) struct Lane<T, P: Teardown> {
     pub(super) key: super::LaneKey,
     pub(super) signal: Arc<LaneSignal>,
-    pub(super) consumer: yring::Consumer<T>,
+    pub(super) consumer: crate::ring::Consumer<T, P>,
     pub(super) cached_available: usize,
     pub(super) unreleased: usize,
     pub(super) release_batch: usize,
 }
 
-pub(super) struct LaneToken<T>(Box<Lane<T>>);
+pub(super) struct LaneToken<T, P: Teardown>(Box<Lane<T, P>>);
 
-impl<T> LaneToken<T> {
-    pub(super) fn new(lane: Lane<T>) -> Self {
+impl<T, P: Teardown> LaneToken<T, P> {
+    pub(super) fn new(lane: Lane<T, P>) -> Self {
         Self(Box::new(lane))
     }
 }
 
-impl<T> Deref for LaneToken<T> {
-    type Target = Lane<T>;
+impl<T, P: Teardown> Deref for LaneToken<T, P> {
+    type Target = Lane<T, P>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T> DerefMut for LaneToken<T> {
+impl<T, P: Teardown> DerefMut for LaneToken<T, P> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<T> Lane<T> {
+impl<T, P: Teardown> Lane<T, P> {
     pub(super) fn new(
         key: super::LaneKey,
         signal: Arc<LaneSignal>,
-        consumer: yring::Consumer<T>,
+        consumer: crate::ring::Consumer<T, P>,
     ) -> Self {
         let release_batch = consumer.capacity().min(PREFETCH_LIMIT);
         Self {
@@ -733,8 +741,8 @@ impl<T> Lane<T> {
     }
 }
 
-pub(super) enum FinishLane<T> {
-    Ready(LaneToken<T>),
+pub(super) enum FinishLane<T, P: Teardown> {
+    Ready(LaneToken<T, P>),
     Parked,
     Retired { wake_all: bool },
 }
@@ -786,7 +794,7 @@ impl Effects {
     }
 }
 
-pub(super) fn close_lane<T>(mut lane: LaneToken<T>) {
+pub(super) fn close_lane<T, P: Teardown>(mut lane: LaneToken<T, P>) {
     lane.consumer.close();
     lane.signal.notify_space();
 }

--- a/src/mpmc/sender.rs
+++ b/src/mpmc/sender.rs
@@ -1,3 +1,5 @@
+use crate::teardown::{Deferred, Teardown};
+
 use std::time::{Duration, Instant};
 
 use crate::compat::{Arc, Ordering};
@@ -12,14 +14,14 @@ use super::{
 /// Each sender owns one SPSC ring producer. Registering senders has no fixed
 /// limit.
 #[derive(Debug)]
-pub struct Sender<T> {
-    pub(super) shared: Arc<Shared<T>>,
-    pub(super) producer: yring::Producer<T>,
+pub struct Sender<T, P: Teardown = Deferred> {
+    pub(super) shared: Arc<Shared<T, P>>,
+    pub(super) producer: crate::ring::Producer<T, P>,
     pub(super) key: LaneKey,
     pub(super) signal: Arc<LaneSignal>,
 }
 
-impl<T> Sender<T> {
+impl<T, P: Teardown> Sender<T, P> {
     /// Try to register another sender.
     #[must_use]
     pub fn try_clone(&self) -> Option<Self> {
@@ -62,9 +64,8 @@ impl<T> Sender<T> {
             return (Err(TrySendError::Disconnected(value)), false);
         }
 
-        match self.producer.push(value) {
+        match self.producer.push_and_flush(value) {
             Ok(()) => {
-                self.producer.flush();
                 let wake_receiver = self.shared.mark_ready(&self.signal);
                 (Ok(()), wake_receiver)
             }
@@ -254,7 +255,7 @@ impl<T> Sender<T> {
     }
 }
 
-impl<T> Drop for Sender<T> {
+impl<T, P: Teardown> Drop for Sender<T, P> {
     fn drop(&mut self) {
         self.producer.close();
         let _ = self.shared.mark_ready(&self.signal);

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -3,6 +3,8 @@
 //! Each sender owns its ring producer and the receiver owns every ring
 //! consumer. Ordering is FIFO per sender and relaxed across senders.
 
+use crate::teardown::{Deferred, Teardown};
+
 use std::fmt;
 
 use crate::compat::{Arc, AtomicBool, AtomicUsize, Mutex, Ordering, lock};
@@ -37,6 +39,9 @@ const PARK_SPINS: usize = 0;
 
 /// Create an MPSC channel with one bounded ring per sender.
 ///
+/// Uses [`Deferred`] teardown. See [`channel_with_policy`] to opt into
+/// cleanup independent of idle sender lifetimes.
+///
 /// `capacity_per_sender` must be between 1 and [`MAX_CAPACITY_PER_SENDER`] and is
 /// rounded up by `yring` to the next power of two.
 ///
@@ -61,12 +66,57 @@ pub fn channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
 pub fn try_channel<T>(
     capacity_per_sender: usize,
 ) -> Result<(Sender<T>, Receiver<T>), ChannelError> {
+    try_channel_with_policy::<T, Deferred>(capacity_per_sender)
+}
+
+/// Create a channel with an explicit teardown policy.
+///
+/// [`Deferred`] is the default used by [`channel`].
+/// [`Coordinated`](crate::teardown::Coordinated) destroys unread payloads while
+/// sender handles remain alive; an overlapping send may finish cleanup later.
+/// The policy is inherited by all cloned handles.
+///
+/// # Panics
+///
+/// Panics when capacity is zero or exceeds [`MAX_CAPACITY_PER_SENDER`].
+///
+/// # Example
+///
+/// ```
+/// use fanring::{mpsc, teardown::Coordinated};
+/// let (mut tx, rx) = mpsc::channel_with_policy::<_, Coordinated>(4);
+/// let (reply, response) = std::sync::mpsc::channel::<()>();
+/// tx.try_send(reply).unwrap();
+/// drop(rx);
+/// assert_eq!(response.try_recv(), Err(std::sync::mpsc::TryRecvError::Disconnected));
+/// drop(tx);
+/// ```
+#[must_use]
+pub fn channel_with_policy<T, P: Teardown>(
+    capacity_per_sender: usize,
+) -> (Sender<T, P>, Receiver<T, P>) {
+    try_channel_with_policy(capacity_per_sender).unwrap_or_else(|error| panic!("{error}"))
+}
+
+/// Fallible version of [`channel_with_policy`].
+///
+/// # Errors
+///
+/// Returns [`ChannelError`] when capacity is zero or exceeds
+/// [`MAX_CAPACITY_PER_SENDER`].
+#[allow(
+    clippy::type_complexity,
+    reason = "channel constructor returns its two endpoints"
+)]
+pub fn try_channel_with_policy<T, P: Teardown>(
+    capacity_per_sender: usize,
+) -> Result<(Sender<T, P>, Receiver<T, P>), ChannelError> {
     validate_capacity(capacity_per_sender, MAX_CAPACITY_PER_SENDER)?;
     Ok(build_channel(capacity_per_sender))
 }
 
-fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
-    let (producer, consumer) = yring::spsc(capacity_per_sender);
+fn build_channel<T, P: Teardown>(capacity_per_sender: usize) -> (Sender<T, P>, Receiver<T, P>) {
+    let (producer, consumer) = crate::ring::spsc(capacity_per_sender);
     let group = Arc::new(ReadyGroup::new(0));
     let page = Arc::new(ReadyPage::new(0, group.clone()));
     let signal = Arc::new(LaneSignal::new(page.clone(), 0));
@@ -111,8 +161,8 @@ fn build_channel<T>(capacity_per_sender: usize) -> (Sender<T>, Receiver<T>) {
     )
 }
 
-struct Shared<T> {
-    registry: Mutex<Registry<T>>,
+struct Shared<T, P: Teardown> {
+    registry: Mutex<Registry<T, P>>,
     registry_generation: AtomicUsize,
     registered_lanes: AtomicUsize,
     live_senders: AtomicUsize,
@@ -121,11 +171,15 @@ struct Shared<T> {
     capacity_per_sender: usize,
 }
 
-impl<T> Shared<T> {
+impl<T, P: Teardown> Shared<T, P> {
     #[allow(clippy::significant_drop_tightening)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "registration returns the lane key, readiness signal, and producer"
+    )]
     fn register_sender(
         &self,
-    ) -> Result<(LaneKey, Arc<LaneSignal>, yring::Producer<T>), TryRegisterError> {
+    ) -> Result<(LaneKey, Arc<LaneSignal>, crate::ring::Producer<T, P>), TryRegisterError> {
         if !self.receiver_alive.load(Ordering::Acquire) {
             return Err(TryRegisterError::Disconnected);
         }
@@ -137,7 +191,7 @@ impl<T> Shared<T> {
 
         let (key, page) = registry.allocate_lane();
         let signal = Arc::new(LaneSignal::new(page, key.slot));
-        let (producer, consumer) = yring::spsc(self.capacity_per_sender);
+        let (producer, consumer) = crate::ring::spsc(self.capacity_per_sender);
         registry.pending.push(PendingLane {
             key,
             signal: signal.clone(),
@@ -156,7 +210,7 @@ impl<T> Shared<T> {
     }
 }
 
-impl<T> fmt::Debug for Shared<T> {
+impl<T, P: Teardown> fmt::Debug for Shared<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Shared")
             .field(
@@ -179,21 +233,21 @@ struct LaneKey {
     generation: usize,
 }
 
-struct PendingLane<T> {
+struct PendingLane<T, P: Teardown> {
     key: LaneKey,
     signal: Arc<LaneSignal>,
-    consumer: yring::Consumer<T>,
+    consumer: crate::ring::Consumer<T, P>,
 }
 
-struct Registry<T> {
-    pending: Vec<PendingLane<T>>,
+struct Registry<T, P: Teardown> {
+    pending: Vec<PendingLane<T, P>>,
     free: Vec<LaneKey>,
     groups: Vec<Arc<ReadyGroup>>,
     pages: Vec<Arc<ReadyPage>>,
     next_slot: usize,
 }
 
-impl<T> Registry<T> {
+impl<T, P: Teardown> Registry<T, P> {
     fn allocate_lane(&mut self) -> (LaneKey, Arc<ReadyPage>) {
         let key = self.free.pop().unwrap_or_else(|| {
             let key = LaneKey {

--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -1,3 +1,5 @@
+use crate::teardown::{Deferred, Teardown};
+
 use std::collections::VecDeque;
 use std::fmt;
 use std::mem;
@@ -15,9 +17,14 @@ use super::{
 ///
 /// The receiver owns every SPSC consumer and drains active lanes in bounded
 /// round-robin bursts. It is `Send` when `T` is `Send`, but it is not `Sync`.
-pub struct Receiver<T> {
-    pub(super) shared: Arc<Shared<T>>,
-    pub(super) lanes: Vec<Option<Lane<T>>>,
+///
+/// Dropping the last receiver disconnects senders. Unread payload destruction
+/// follows `P`: [`Deferred`] may retain ring values until their sender drops;
+/// [`Coordinated`](crate::teardown::Coordinated) reclaims them during teardown
+/// or when an overlapping send resumes.
+pub struct Receiver<T, P: Teardown = Deferred> {
+    pub(super) shared: Arc<Shared<T, P>>,
+    pub(super) lanes: Vec<Option<Lane<T, P>>>,
     pub(super) groups: Vec<Arc<ReadyGroup>>,
     pub(super) pages: Vec<Arc<ReadyPage>>,
     pub(super) active: VecDeque<LaneKey>,
@@ -27,7 +34,7 @@ pub struct Receiver<T> {
     pub(super) capacity_per_sender: usize,
 }
 
-impl<T> Receiver<T> {
+impl<T, P: Teardown> Receiver<T, P> {
     /// Try to receive one value.
     ///
     /// # Errors
@@ -458,30 +465,34 @@ impl<T> Receiver<T> {
     /// Iterate until every sender disconnects and buffered values are drained.
     #[inline]
     #[must_use]
-    pub const fn iter(&mut self) -> Iter<'_, T> {
+    pub const fn iter(&mut self) -> Iter<'_, T, P> {
         Iter { receiver: self }
     }
 
     /// Iterate over values immediately available without blocking.
     #[inline]
     #[must_use]
-    pub const fn try_iter(&mut self) -> TryIter<'_, T> {
+    pub const fn try_iter(&mut self) -> TryIter<'_, T, P> {
         TryIter { receiver: self }
     }
 }
 
-pub(super) struct Lane<T> {
+pub(super) struct Lane<T, P: Teardown> {
     key: LaneKey,
     signal: Arc<LaneSignal>,
-    consumer: yring::Consumer<T>,
+    consumer: crate::ring::Consumer<T, P>,
     cached_available: usize,
     unreleased: usize,
     release_batch: usize,
     burst: usize,
 }
 
-impl<T> Lane<T> {
-    pub(super) fn new(key: LaneKey, signal: Arc<LaneSignal>, consumer: yring::Consumer<T>) -> Self {
+impl<T, P: Teardown> Lane<T, P> {
+    pub(super) fn new(
+        key: LaneKey,
+        signal: Arc<LaneSignal>,
+        consumer: crate::ring::Consumer<T, P>,
+    ) -> Self {
         let release_batch = consumer.capacity().min(PREFETCH_LIMIT);
         Self {
             key,
@@ -521,7 +532,7 @@ enum LanePoll<T> {
     Stale,
 }
 
-impl<T> Drop for Receiver<T> {
+impl<T, P: Teardown> Drop for Receiver<T, P> {
     fn drop(&mut self) {
         self.shared.receiver_alive.store(false, Ordering::Release);
         for lane in self.lanes.iter_mut().flatten() {
@@ -539,7 +550,7 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
-impl<T> fmt::Debug for Receiver<T> {
+impl<T, P: Teardown> fmt::Debug for Receiver<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver")
             .field("active_lanes", &self.active.len())
@@ -554,11 +565,11 @@ impl<T> fmt::Debug for Receiver<T> {
 
 /// Blocking iterator over a borrowed receiver.
 #[derive(Debug)]
-pub struct Iter<'a, T> {
-    receiver: &'a mut Receiver<T>,
+pub struct Iter<'a, T, P: Teardown = Deferred> {
+    receiver: &'a mut Receiver<T, P>,
 }
 
-impl<T> Iterator for Iter<'_, T> {
+impl<T, P: Teardown> Iterator for Iter<'_, T, P> {
     type Item = T;
 
     #[inline]
@@ -567,15 +578,15 @@ impl<T> Iterator for Iter<'_, T> {
     }
 }
 
-impl<T> std::iter::FusedIterator for Iter<'_, T> {}
+impl<T, P: Teardown> std::iter::FusedIterator for Iter<'_, T, P> {}
 
 /// Nonblocking iterator over a borrowed receiver.
 #[derive(Debug)]
-pub struct TryIter<'a, T> {
-    receiver: &'a mut Receiver<T>,
+pub struct TryIter<'a, T, P: Teardown = Deferred> {
+    receiver: &'a mut Receiver<T, P>,
 }
 
-impl<T> Iterator for TryIter<'_, T> {
+impl<T, P: Teardown> Iterator for TryIter<'_, T, P> {
     type Item = T;
 
     #[inline]
@@ -586,11 +597,11 @@ impl<T> Iterator for TryIter<'_, T> {
 
 /// Blocking iterator that owns its receiver.
 #[derive(Debug)]
-pub struct IntoIter<T> {
-    receiver: Receiver<T>,
+pub struct IntoIter<T, P: Teardown = Deferred> {
+    receiver: Receiver<T, P>,
 }
 
-impl<T> Iterator for IntoIter<T> {
+impl<T, P: Teardown> Iterator for IntoIter<T, P> {
     type Item = T;
 
     #[inline]
@@ -599,15 +610,15 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
-impl<T> std::iter::FusedIterator for IntoIter<T> {}
+impl<T, P: Teardown> std::iter::FusedIterator for IntoIter<T, P> {}
 
 #[allow(
     clippy::into_iter_without_iter,
     reason = "channel convention names the blocking iterator iter"
 )]
-impl<'a, T> IntoIterator for &'a mut Receiver<T> {
+impl<'a, T, P: Teardown> IntoIterator for &'a mut Receiver<T, P> {
     type Item = T;
-    type IntoIter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T, P>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -615,9 +626,9 @@ impl<'a, T> IntoIterator for &'a mut Receiver<T> {
     }
 }
 
-impl<T> IntoIterator for Receiver<T> {
+impl<T, P: Teardown> IntoIterator for Receiver<T, P> {
     type Item = T;
-    type IntoIter = IntoIter<T>;
+    type IntoIter = IntoIter<T, P>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {

--- a/src/mpsc/sender.rs
+++ b/src/mpsc/sender.rs
@@ -1,3 +1,5 @@
+use crate::teardown::{Deferred, Teardown};
+
 use std::time::{Duration, Instant};
 
 use crate::compat::{Arc, Ordering};
@@ -12,14 +14,14 @@ use super::{
 /// A `Sender` owns exactly one SPSC ring producer. It is `Send` when `T` is
 /// `Send`, but it is not `Sync`. Sender registration has no configured limit.
 #[derive(Debug)]
-pub struct Sender<T> {
-    pub(super) shared: Arc<Shared<T>>,
-    pub(super) producer: yring::Producer<T>,
+pub struct Sender<T, P: Teardown = Deferred> {
+    pub(super) shared: Arc<Shared<T, P>>,
+    pub(super) producer: crate::ring::Producer<T, P>,
     pub(super) key: LaneKey,
     pub(super) signal: Arc<LaneSignal>,
 }
 
-impl<T> Sender<T> {
+impl<T, P: Teardown> Sender<T, P> {
     /// Try to register another sender.
     ///
     /// Returns `None` when the receiver is gone.
@@ -70,9 +72,8 @@ impl<T> Sender<T> {
             return (Err(TrySendError::Disconnected(value)), false);
         }
 
-        match self.producer.push(value) {
+        match self.producer.push_and_flush(value) {
             Ok(()) => {
-                self.producer.flush();
                 let wake_receiver = self.shared.mark_ready(&self.signal);
                 (Ok(()), wake_receiver)
             }
@@ -261,7 +262,7 @@ impl<T> Sender<T> {
     }
 }
 
-impl<T> Drop for Sender<T> {
+impl<T, P: Teardown> Drop for Sender<T, P> {
     fn drop(&mut self) {
         self.producer.close();
         let _ = self.shared.mark_ready(&self.signal);

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,0 +1,347 @@
+//! SPSC ownership handoff for receiver teardown.
+//!
+//! Closing a yring consumer alone retains unread values until its producer
+//! drops. Deferred keeps that behavior. Coordinated gives cleanup ownership
+//! to the receiver or to an overlapping send when it finishes.
+
+use std::marker::PhantomData;
+
+use crate::compat::{Arc, AtomicU8, Mutex, Ordering, lock};
+use crate::teardown::Teardown;
+
+const ACTIVE: u8 = 1;
+const CLOSED: u8 = 2;
+
+pub(crate) fn spsc<T, P: Teardown>(capacity: usize) -> (Producer<T, P>, Consumer<T, P>) {
+    let (producer, consumer) = yring::spsc(capacity);
+    let cleanup = P::COORDINATED.then(|| {
+        Arc::new(Cleanup {
+            state: AtomicU8::new(0),
+            consumer: Mutex::new(None),
+        })
+    });
+    (
+        Producer {
+            inner: producer,
+            cleanup: cleanup.clone(),
+            policy: PhantomData,
+        },
+        Consumer {
+            inner: Some(consumer),
+            cleanup,
+            policy: PhantomData,
+        },
+    )
+}
+
+#[derive(Debug)]
+struct Cleanup<T> {
+    state: AtomicU8,
+    consumer: Mutex<Option<yring::Consumer<T>>>,
+}
+
+impl<T> Cleanup<T> {
+    #[inline]
+    fn begin(&self) -> Option<SendGuard<'_, T>> {
+        self.state
+            .compare_exchange(0, ACTIVE, Ordering::Acquire, Ordering::Relaxed)
+            .ok()
+            .map(|_| SendGuard(self))
+    }
+
+    fn close(&self, consumer: yring::Consumer<T>) {
+        // Acquire the handoff slot before announcing CLOSED. The sender only
+        // locks it after observing CLOSED, so teardown never waits for a
+        // paused sender holding this mutex.
+        let mut slot = lock(&self.consumer);
+        *slot = Some(consumer);
+        let previous = self.state.fetch_or(CLOSED, Ordering::AcqRel);
+        let consumer = if previous & ACTIVE == 0 {
+            slot.take()
+        } else {
+            None
+        };
+        drop(slot);
+        if let Some(mut consumer) = consumer {
+            discard(&mut consumer);
+        }
+    }
+}
+
+struct SendGuard<'a, T>(&'a Cleanup<T>);
+
+impl<T> Drop for SendGuard<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.state.fetch_and(!ACTIVE, Ordering::AcqRel) & CLOSED != 0 {
+            // Taking ownership before dropping payloads avoids running user
+            // destructors under the handoff mutex.
+            let consumer = lock(&self.0.consumer).take();
+            if let Some(mut consumer) = consumer {
+                discard(&mut consumer);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Producer<T, P: Teardown> {
+    inner: yring::Producer<T>,
+    cleanup: Option<Arc<Cleanup<T>>>,
+    policy: PhantomData<P>,
+}
+
+impl<T, P: Teardown> Producer<T, P> {
+    #[inline]
+    pub(crate) fn push_and_flush(&mut self, value: T) -> Result<(), T> {
+        if !P::COORDINATED {
+            self.inner.push(value)?;
+            self.inner.flush();
+            return Ok(());
+        }
+        let Some(_send) = self.cleanup.as_ref().expect("coordinated cleanup").begin() else {
+            return Err(value);
+        };
+        self.inner.push(value)?;
+        self.inner.flush();
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    #[inline]
+    pub(crate) fn is_consumer_dropped(&self) -> bool {
+        if P::COORDINATED {
+            self.cleanup
+                .as_ref()
+                .expect("coordinated cleanup")
+                .state
+                .load(Ordering::Acquire)
+                & CLOSED
+                != 0
+        } else {
+            self.inner.is_consumer_dropped()
+        }
+    }
+
+    #[inline]
+    pub(crate) fn close(&mut self) {
+        self.inner.close();
+    }
+}
+
+pub(crate) struct Consumer<T, P: Teardown> {
+    inner: Option<yring::Consumer<T>>,
+    cleanup: Option<Arc<Cleanup<T>>>,
+    policy: PhantomData<P>,
+}
+
+impl<T, P: Teardown> Consumer<T, P> {
+    #[inline]
+    pub(crate) fn pop(&mut self) -> Option<T> {
+        self.inner.as_mut().expect("consumer is open").pop()
+    }
+
+    #[inline]
+    pub(crate) fn prefetch(&mut self) -> usize {
+        self.inner.as_mut().expect("consumer is open").prefetch()
+    }
+
+    #[inline]
+    pub(crate) fn release(&mut self) {
+        self.inner.as_mut().expect("consumer is open").release();
+    }
+
+    #[inline]
+    pub(crate) fn capacity(&self) -> usize {
+        self.inner.as_ref().expect("consumer is open").capacity()
+    }
+
+    #[inline]
+    pub(crate) fn is_disconnected(&self) -> bool {
+        self.inner
+            .as_ref()
+            .expect("consumer is open")
+            .is_disconnected()
+    }
+
+    pub(crate) fn close(&mut self) {
+        if let Some(mut consumer) = self.inner.take() {
+            // Dispose of the current window even if a producer is paused.
+            // The ownership handoff covers writes published after this drain.
+            if P::COORDINATED {
+                discard(&mut consumer);
+                self.cleanup
+                    .as_ref()
+                    .expect("coordinated cleanup")
+                    .close(consumer);
+            } else {
+                consumer.close();
+            }
+        }
+    }
+}
+
+impl<T, P: Teardown> Drop for Consumer<T, P> {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+fn discard<T>(consumer: &mut yring::Consumer<T>) {
+    // prefetch() counts newly flushed values, not the unread part of an
+    // existing window. Always pop the whole window, including a partial batch.
+    consumer.prefetch();
+    while let Some(value) = consumer.pop() {
+        drop(value);
+    }
+    // Keep slot credit reserved until the final owner drops the consumer.
+    // Releasing during the first drain could let an in-flight send reuse a
+    // formerly full slot and succeed solely because the receiver is closing.
+}
+
+#[cfg(all(test, not(loom)))]
+mod tests {
+    use crate::teardown::Coordinated;
+    fn spsc<T>(
+        capacity: usize,
+    ) -> (
+        super::Producer<T, Coordinated>,
+        super::Consumer<T, Coordinated>,
+    ) {
+        super::spsc(capacity)
+    }
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct Counted(Arc<AtomicUsize>);
+
+    impl Drop for Counted {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn close_keeps_full_slot_reserved_until_active_send_finishes() {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (mut tx, rx) = spsc(1);
+        tx.push_and_flush(Counted(drops.clone())).unwrap();
+        let send = tx.cleanup.as_ref().unwrap().begin().unwrap();
+        drop(rx);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+        let value = tx.inner.push(Counted(drops.clone())).unwrap_err();
+        drop(send);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+        drop(value);
+        assert_eq!(drops.load(Ordering::Relaxed), 2);
+        drop(tx);
+        assert_eq!(drops.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn close_does_not_wait_for_paused_publication() {
+        // Pause after acquiring publication ownership, on both sides of the
+        // payload write and the flush. The producer stays alive for assertions.
+        for phase in 0..3 {
+            let first = Arc::new(AtomicUsize::new(0));
+            let second = Arc::new(AtomicUsize::new(0));
+            let (mut tx, rx) = spsc(2);
+            tx.push_and_flush(Counted(first.clone())).unwrap();
+            let value = Counted(second.clone());
+            let (paused_tx, paused_rx) = std::sync::mpsc::channel();
+            let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+            let sender = std::thread::spawn(move || {
+                let send = tx.cleanup.as_ref().unwrap().begin().unwrap();
+                if phase == 0 {
+                    paused_tx.send(()).unwrap();
+                    resume_rx.recv().unwrap();
+                }
+                tx.inner.push(value).unwrap();
+                if phase == 1 {
+                    paused_tx.send(()).unwrap();
+                    resume_rx.recv().unwrap();
+                }
+                tx.inner.flush();
+                if phase == 2 {
+                    paused_tx.send(()).unwrap();
+                    resume_rx.recv().unwrap();
+                }
+                drop(send);
+                tx
+            });
+            paused_rx.recv().unwrap();
+            let (closed_tx, closed_rx) = std::sync::mpsc::channel();
+            let receiver = std::thread::spawn(move || {
+                drop(rx);
+                closed_tx.send(()).unwrap();
+            });
+            let closed = closed_rx.recv_timeout(Duration::from_secs(5));
+            let first_at_close = first.load(Ordering::Relaxed);
+            let second_at_close = second.load(Ordering::Relaxed);
+            // Resume even on timeout, so a failing test can join its threads.
+            resume_tx.send(()).unwrap();
+            receiver.join().unwrap();
+            let tx = sender.join().unwrap();
+            assert_eq!(closed, Ok(()), "phase {phase}");
+            assert_eq!(first_at_close, 1, "phase {phase}");
+            assert_eq!(second_at_close, usize::from(phase == 2), "phase {phase}");
+            assert_eq!(first.load(Ordering::Relaxed), 1);
+            assert_eq!(second.load(Ordering::Relaxed), 1);
+            drop(tx);
+            assert_eq!(first.load(Ordering::Relaxed), 1);
+            assert_eq!(second.load(Ordering::Relaxed), 1);
+        }
+    }
+}
+
+#[cfg(all(test, loom, target_pointer_width = "64"))]
+mod loom_tests {
+    use crate::teardown::Coordinated;
+    fn spsc<T>(
+        capacity: usize,
+    ) -> (
+        super::Producer<T, Coordinated>,
+        super::Consumer<T, Coordinated>,
+    ) {
+        super::spsc(capacity)
+    }
+    use loom::sync::Arc;
+    use loom::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct Counted(Arc<AtomicUsize>);
+
+    impl Drop for Counted {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn close_racing_publication_drops_each_value_once() {
+        loom::model(|| {
+            let first = Arc::new(AtomicUsize::new(0));
+            let second = Arc::new(AtomicUsize::new(0));
+            let (mut tx, rx) = spsc(2);
+            tx.push_and_flush(Counted(first.clone())).unwrap();
+            let value = Counted(second.clone());
+            let sender = loom::thread::spawn(move || {
+                drop(tx.push_and_flush(value));
+                tx
+            });
+            drop(rx);
+            let tx = sender.join().unwrap();
+            assert_eq!(first.load(Ordering::Relaxed), 1);
+            assert_eq!(second.load(Ordering::Relaxed), 1);
+            drop(tx);
+            assert_eq!(first.load(Ordering::Relaxed), 1);
+            assert_eq!(second.load(Ordering::Relaxed), 1);
+        });
+    }
+}

--- a/src/teardown.rs
+++ b/src/teardown.rs
@@ -1,0 +1,53 @@
+//! Choose when unread payloads are destroyed after the last receiver drops.
+//!
+//! Both policies disconnect the channel and wake blocked senders. The policy
+//! is fixed at construction and inherited by every cloned handle and lane.
+//! It is part of the channel type, so deferred sends omit cleanup coordination.
+
+use std::fmt::Debug;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A channel's teardown policy. Only [`Deferred`] and [`Coordinated`] implement it.
+pub trait Teardown: sealed::Sealed + Debug + Send + Sync + 'static {
+    #[doc(hidden)]
+    const COORDINATED: bool;
+}
+
+/// Defer destruction of unread ring payloads until their sender releases the ring.
+///
+/// This is the default. Dropping the last receiver disconnects the channel but
+/// may retain unread payloads for as long as sender handles remain alive.
+/// Receiver-local staged values can be destroyed earlier. Payload destructors
+/// must tolerate this delay; queued reply senders and permits remain alive too.
+/// No cleanup handshake is performed on sends.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Deferred;
+
+/// Reclaim unread payloads without requiring sender handles to be dropped.
+///
+/// The last receiver drains unread values and hands any remaining cleanup to
+/// an overlapping send. Late publications are destroyed when that send resumes.
+/// Receiver teardown does not wait for a paused producer, so destruction of a
+/// late publication can occur after receiver drop returns. Payload destructors
+/// run on either the receiver or producer thread, outside the handoff mutex.
+/// As with ordinary Rust destruction, a payload destructor itself can block or
+/// panic. Ring allocations still live as long as their sender handles.
+///
+/// Sends pay for an atomic ownership handshake. Use this policy when reply
+/// cancellation or resource release must not depend on idle sender lifetimes.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Coordinated;
+
+impl sealed::Sealed for Deferred {}
+impl sealed::Sealed for Coordinated {}
+
+impl Teardown for Deferred {
+    const COORDINATED: bool = false;
+}
+
+impl Teardown for Coordinated {
+    const COORDINATED: bool = true;
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -20,6 +20,106 @@ fn model(check: impl Fn() + Sync + Send + 'static) {
     builder.check(check);
 }
 
+#[derive(Debug)]
+struct DropCount(Arc<loom::sync::atomic::AtomicUsize>);
+
+impl Drop for DropCount {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+macro_rules! drop_cleanup_models {
+    ($module:ident, $kind:ident) => {
+        mod $module {
+            use super::{DropCount, model};
+            use fanring::teardown::Coordinated;
+            fn channel<T>(
+                capacity: usize,
+            ) -> (
+                fanring::$kind::Sender<T, Coordinated>,
+                fanring::$kind::Receiver<T, Coordinated>,
+            ) {
+                fanring::$kind::channel_with_policy(capacity)
+            }
+            use loom::sync::Arc;
+            use loom::sync::atomic::{AtomicUsize, Ordering};
+            use loom::thread;
+
+            #[test]
+            fn deferred_close_racing_send_retains_then_drops_exactly_once() {
+                model(|| {
+                    let first = Arc::new(AtomicUsize::new(0));
+                    let second = Arc::new(AtomicUsize::new(0));
+                    let (mut tx, rx) = fanring::$kind::channel(2);
+                    tx.try_send(DropCount(first.clone())).unwrap();
+                    let value = DropCount(second.clone());
+                    let sender = thread::spawn(move || {
+                        drop(tx.try_send(value));
+                        tx
+                    });
+                    drop(rx);
+                    let tx = sender.join().unwrap();
+                    assert_eq!(first.load(Ordering::Relaxed), 0);
+                    assert!(second.load(Ordering::Relaxed) <= 1);
+                    assert!(tx.is_disconnected());
+                    drop(tx);
+                    assert_eq!(first.load(Ordering::Relaxed), 1);
+                    assert_eq!(second.load(Ordering::Relaxed), 1);
+                });
+            }
+
+            #[test]
+            fn receiver_drop_racing_send_releases_payloads_with_sender_alive() {
+                model(|| {
+                    let first = Arc::new(AtomicUsize::new(0));
+                    let second = Arc::new(AtomicUsize::new(0));
+                    let (mut tx, rx) = channel(2);
+                    tx.try_send(DropCount(first.clone())).unwrap();
+                    let value = DropCount(second.clone());
+                    let sender = thread::spawn(move || {
+                        drop(tx.try_send(value));
+                        tx
+                    });
+                    drop(rx);
+                    let tx = sender.join().unwrap();
+                    assert_eq!(first.load(Ordering::Relaxed), 1);
+                    assert_eq!(second.load(Ordering::Relaxed), 1);
+                    drop(tx);
+                    assert_eq!(first.load(Ordering::Relaxed), 1);
+                    assert_eq!(second.load(Ordering::Relaxed), 1);
+                });
+            }
+
+            #[test]
+            fn receiver_drop_racing_registration_releases_payload_with_senders_alive() {
+                model(|| {
+                    let drops = Arc::new(AtomicUsize::new(0));
+                    let (root, rx) = channel(1);
+                    let value = DropCount(drops.clone());
+                    let registrar = thread::spawn(move || {
+                        let mut child = root.try_clone();
+                        if let Some(tx) = &mut child {
+                            drop(tx.try_send(value));
+                        } else {
+                            drop(value);
+                        }
+                        (root, child)
+                    });
+                    drop(rx);
+                    let senders = registrar.join().unwrap();
+                    assert_eq!(drops.load(Ordering::Relaxed), 1);
+                    drop(senders);
+                    assert_eq!(drops.load(Ordering::Relaxed), 1);
+                });
+            }
+        }
+    };
+}
+
+drop_cleanup_models!(mpsc_cleanup, mpsc);
+drop_cleanup_models!(mpmc_cleanup, mpmc);
+
 #[test]
 fn send_recv_ready_race_does_not_lose_message() {
     model(|| {

--- a/tests/receiver_drop.rs
+++ b/tests/receiver_drop.rs
@@ -1,0 +1,251 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+
+#[cfg(miri)]
+const RACE_ROUNDS: usize = 2;
+#[cfg(not(miri))]
+const RACE_ROUNDS: usize = 256;
+
+#[derive(Debug)]
+struct Counted {
+    id: usize,
+    drops: Arc<Vec<AtomicUsize>>,
+}
+
+impl Drop for Counted {
+    fn drop(&mut self) {
+        self.drops[self.id].fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn counters(count: usize) -> Arc<Vec<AtomicUsize>> {
+    Arc::new((0..count).map(|_| AtomicUsize::new(0)).collect())
+}
+
+fn counted(drops: &Arc<Vec<AtomicUsize>>, id: usize) -> Counted {
+    Counted {
+        id,
+        drops: drops.clone(),
+    }
+}
+
+fn assert_drops(drops: &[AtomicUsize], expected: usize) {
+    for (id, count) in drops.iter().enumerate() {
+        assert_eq!(count.load(Ordering::Relaxed), expected, "payload {id}");
+    }
+}
+
+macro_rules! receiver_drop_tests {
+    ($kind:ident) => {
+        mod $kind {
+            use super::*;
+            use fanring::teardown::Coordinated;
+            use fanring::$kind::channel_with_policy;
+            fn channel<T>(
+                capacity: usize,
+            ) -> (
+                fanring::$kind::Sender<T, Coordinated>,
+                fanring::$kind::Receiver<T, Coordinated>,
+            ) {
+                channel_with_policy(capacity)
+            }
+
+            #[test]
+            fn default_defers_each_lane_until_its_sender_drops() {
+                for register in [false, true] {
+                    let drops = counters(2);
+                    let (mut tx, mut rx) = fanring::$kind::channel(4);
+                    let mut cloned = tx.try_clone().unwrap();
+                    if register {
+                        assert!(rx.try_recv().is_err());
+                    }
+                    tx.try_send(counted(&drops, 0)).unwrap();
+                    cloned.try_send(counted(&drops, 1)).unwrap();
+                    drop(rx);
+                    assert!(tx.is_disconnected());
+                    assert!(cloned.is_disconnected());
+                    assert_drops(&drops, 0);
+                    drop(cloned);
+                    assert_eq!(drops[0].load(Ordering::Relaxed), 0);
+                    assert_eq!(drops[1].load(Ordering::Relaxed), 1);
+                    drop(tx);
+                    assert_drops(&drops, 1);
+                }
+            }
+
+            #[test]
+            fn both_policies_preserve_operations_and_sender_disconnect() {
+                fn check<P: fanring::teardown::Teardown>() {
+                    let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+                    let mut cloned = tx.try_clone().unwrap();
+                    tx.send_timeout(1, std::time::Duration::ZERO).unwrap();
+                    cloned.send(2).unwrap();
+                    drop((tx, cloned));
+                    let mut values: Vec<_> = rx.iter().collect();
+                    values.sort_unstable();
+                    assert_eq!(values, [1, 2]);
+                    assert!(rx.try_iter().next().is_none());
+                    assert!(rx.into_iter().next().is_none());
+                }
+                check::<fanring::teardown::Deferred>();
+                check::<Coordinated>();
+            }
+
+            #[test]
+            fn queued_reply_disconnects_while_sender_lives() {
+                let (mut tx, rx) = channel(4);
+                let (reply_tx, reply_rx) = std::sync::mpsc::channel::<()>();
+                tx.try_send(reply_tx).unwrap();
+                drop(rx);
+                assert!(tx.is_disconnected());
+                assert_eq!(
+                    reply_rx.try_recv(),
+                    Err(std::sync::mpsc::TryRecvError::Disconnected)
+                );
+                drop(tx);
+            }
+
+            #[test]
+            fn initial_and_cloned_lanes_drop_unread_values() {
+                for register in [false, true] {
+                    let drops = counters(8);
+                    let (mut tx0, mut rx) = channel(4);
+                    let mut tx1 = tx0.try_clone().unwrap();
+                    if register {
+                        assert!(rx.try_recv().is_err());
+                    }
+                    for id in 0..4 {
+                        tx0.try_send(counted(&drops, id)).unwrap();
+                        tx1.try_send(counted(&drops, id + 4)).unwrap();
+                    }
+                    drop(rx);
+                    assert_drops(&drops, 1);
+                    assert!(tx0.is_disconnected());
+                    assert!(tx1.is_disconnected());
+                    drop((tx0, tx1));
+                    assert_drops(&drops, 1);
+                }
+            }
+
+            #[test]
+            fn partial_batch_drops_only_unread_values() {
+                let drops = counters(128);
+                let (mut tx, mut rx) = channel(128);
+                for id in 0..128 {
+                    tx.try_send(counted(&drops, id)).unwrap();
+                }
+                let received: Vec<_> = (0..3).map(|_| rx.try_recv().unwrap()).collect();
+                drop(rx);
+                for (id, count) in drops.iter().enumerate() {
+                    let expected = usize::from(!received.iter().any(|value| value.id == id));
+                    assert_eq!(count.load(Ordering::Relaxed), expected, "payload {id}");
+                }
+                drop(received);
+                assert_drops(&drops, 1);
+                drop(tx);
+                assert_drops(&drops, 1);
+            }
+
+            #[test]
+            fn send_racing_close_drops_values_before_sender_drops() {
+                for _ in 0..RACE_ROUNDS {
+                    let drops = counters(2);
+                    let (mut tx, rx) = channel(2);
+                    tx.try_send(counted(&drops, 0)).unwrap();
+                    let barrier = Arc::new(Barrier::new(2));
+                    let sender_barrier = barrier.clone();
+                    let value = counted(&drops, 1);
+                    let sender = std::thread::spawn(move || {
+                        sender_barrier.wait();
+                        drop(tx.try_send(value));
+                        tx
+                    });
+                    barrier.wait();
+                    drop(rx);
+                    let tx = sender.join().unwrap();
+                    assert_drops(&drops, 1);
+                    assert!(tx.is_disconnected());
+                    drop(tx);
+                    assert_drops(&drops, 1);
+                }
+            }
+
+            #[test]
+            fn registration_and_send_racing_close_release_values() {
+                for _ in 0..RACE_ROUNDS {
+                    let drops = counters(1);
+                    let (root, rx) = channel(2);
+                    let barrier = Arc::new(Barrier::new(2));
+                    let sender_barrier = barrier.clone();
+                    let value = counted(&drops, 0);
+                    let registrar = std::thread::spawn(move || {
+                        sender_barrier.wait();
+                        let mut child = root.try_clone();
+                        if let Some(tx) = &mut child {
+                            drop(tx.try_send(value));
+                        } else {
+                            drop(value);
+                        }
+                        (root, child)
+                    });
+                    barrier.wait();
+                    drop(rx);
+                    let senders = registrar.join().unwrap();
+                    assert_drops(&drops, 1);
+                    drop(senders);
+                    assert_drops(&drops, 1);
+                }
+            }
+        }
+    };
+}
+
+receiver_drop_tests!(mpsc);
+receiver_drop_tests!(mpmc);
+
+#[test]
+fn nonlast_mpmc_receiver_preserves_private_and_shared_batches() {
+    for clone_before_prefetch in [false, true] {
+        let drops = counters(128);
+        let (mut tx, mut rx0) =
+            fanring::mpmc::channel_with_policy::<_, fanring::teardown::Coordinated>(128);
+        for id in 0..128 {
+            tx.try_send(counted(&drops, id)).unwrap();
+        }
+        let rx1 = clone_before_prefetch.then(|| rx0.clone());
+        let received = rx0.try_recv().unwrap();
+        let mut rx1 = rx1.unwrap_or_else(|| rx0.clone());
+        drop(rx0);
+        assert_drops(&drops, 0);
+        assert!(!tx.is_disconnected());
+        // Orphaned work and the partially consumed lane must remain readable.
+        let mut received = vec![received];
+        received.extend((0..127).map(|_| rx1.try_recv().unwrap()));
+        assert_drops(&drops, 0);
+        drop(rx1);
+        assert!(tx.is_disconnected());
+        assert_drops(&drops, 0);
+        drop(received);
+        assert_drops(&drops, 1);
+        drop(tx);
+        assert_drops(&drops, 1);
+    }
+}
+
+#[test]
+fn last_mpmc_receiver_drops_orphaned_work_and_requeued_lane() {
+    let drops = counters(128);
+    let (mut tx, mut rx0) =
+        fanring::mpmc::channel_with_policy::<_, fanring::teardown::Coordinated>(128);
+    let rx1 = rx0.clone();
+    for id in 0..128 {
+        tx.try_send(counted(&drops, id)).unwrap();
+    }
+    drop(rx0.try_recv().unwrap());
+    drop(rx0);
+    drop(rx1);
+    assert_drops(&drops, 1);
+    assert!(tx.is_disconnected());
+    drop(tx);
+    assert_drops(&drops, 1);
+}

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -126,7 +126,7 @@ fn drops_remaining_items_once() {
     DROPS.store(0, Ordering::Relaxed);
 
     let token = Arc::new(());
-    let (mut tx0, rx) = channel(8);
+    let (mut tx0, rx) = fanring::mpsc::channel_with_policy::<_, fanring::teardown::Coordinated>(8);
     let mut tx1 = tx0.try_clone().unwrap();
 
     for _ in 0..8 {
@@ -135,6 +135,7 @@ fn drops_remaining_items_once() {
     }
 
     drop(rx);
+    assert_eq!(DROPS.load(Ordering::Relaxed), 16);
     drop(tx0);
     drop(tx1);
 


### PR DESCRIPTION
- Add per-channel `Deferred` and `Coordinated` teardown policies, keeping `Deferred` as the default.
- Reclaim unread payloads with `Coordinated` while sender handles remain alive; overlapping sends finish late cleanup without making receiver teardown wait for paused producers.
- Cover concurrent send/close, lane registration, partial batches, and MPMC last-receiver cleanup.
- Add `u64` policy benchmarks and charts, documented competitor retention behavior, and a runnable comparison probe.
