### PR TITLE
fix: preserve MPMC work beyond cached topology

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,6 +29,11 @@ tokens. The immutable page/group topology is published with `ArcSwap` only
 when registration crosses a 64-lane boundary; each receiver caches it until a
 generation change.
 
+Topology snapshots freeze the page/group vectors. Their referenced readiness
+groups remain shared and mutable, so a claimed bit can name a page registered
+after the snapshot was cached. Work claims and lane requeues resolve missing
+pages through the published topology to preserve access to their lane tokens.
+
 The registry also tracks one bounded synchronized work queue per live receiver.
 Receiver creation and drop rebuild an immutable queue snapshot under the
 registry mutex and publish it with `ArcSwap`. Receivers load the snapshot itself

--- a/doc/charts/teardown-mpmc.svg
+++ b/doc/charts/teardown-mpmc.svg
@@ -81,248 +81,248 @@ implementation
 <text x="28" y="161" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring Deferred
 </text>
-<rect x="186" y="149" width="71" height="25" opacity="1" fill="#385B89" stroke="none"/>
+<rect x="186" y="149" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
 <rect x="186" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="221" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-66.1
+63.0
 </text>
 <text x="221" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.6%
-</text>
-<rect x="261" y="149" width="71" height="25" opacity="1" fill="#34537D" stroke="none"/>
-<rect x="261" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-57.5
-</text>
-<text x="296" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.9%
 </text>
-<rect x="336" y="149" width="71" height="25" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="#33537D" stroke="none"/>
+<rect x="261" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="296" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+57.1
+</text>
+<text x="296" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="336" y="149" width="71" height="25" opacity="1" fill="#375A88" stroke="none"/>
 <rect x="336" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="371" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-68.5
+65.1
 </text>
 <text x="371" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-2.4%
++/-2.2%
 </text>
-<rect x="411" y="149" width="71" height="25" opacity="1" fill="#283E5E" stroke="none"/>
+<rect x="411" y="149" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
 <rect x="411" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="446" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-34.1
+36.2
 </text>
 <text x="446" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-14.2%
++/-2.6%
 </text>
-<rect x="494" y="149" width="71" height="25" opacity="1" fill="#385B89" stroke="none"/>
+<rect x="494" y="149" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
 <text x="529" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-66.0
+63.1
 </text>
 <text x="529" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
++/-0.0%
 </text>
-<rect x="569" y="149" width="71" height="25" opacity="1" fill="#355683" stroke="none"/>
-<rect x="569" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="569" y="149" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
 <text x="604" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-61.3
-</text>
-<text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.1%
-</text>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4E83C7" stroke="none"/>
-<rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-112.1
-</text>
-<text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.3%
-</text>
-<rect x="719" y="149" width="71" height="25" opacity="1" fill="#3D6498" stroke="none"/>
-<rect x="719" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-77.2
-</text>
-<text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.2%
-</text>
-<rect x="802" y="149" width="71" height="25" opacity="1" fill="#385A88" stroke="none"/>
-<rect x="802" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="837" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-65.6
-</text>
-<text x="837" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.2%
-</text>
-<rect x="877" y="149" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
-<rect x="877" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="912" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 61.0
 </text>
-<text x="912" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
+<text x="604" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="#4D82C5" stroke="none"/>
+<rect x="644" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="679" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
+110.7
+</text>
+<text x="679" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
++/-0.8%
+</text>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="#3B6193" stroke="none"/>
+<rect x="719" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="754" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+73.9
+</text>
+<text x="754" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-6.9%
+</text>
+<rect x="802" y="149" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
+<text x="837" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+62.9
+</text>
+<text x="837" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.5%
 </text>
-<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4572AD" stroke="none"/>
+<rect x="877" y="149" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<text x="912" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+60.7
+</text>
+<text x="912" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.8%
+</text>
+<rect x="952" y="149" width="71" height="25" opacity="1" fill="#4472AD" stroke="none"/>
 <text x="987" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-93.0
+92.7
 </text>
 <text x="987" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
++/-0.8%
 </text>
-<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5693DE" stroke="none"/>
+<rect x="1027" y="149" width="71" height="25" opacity="1" fill="#5D9FF1" stroke="none"/>
 <rect x="1027" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1062" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-129.4
+142.9
 </text>
 <text x="1062" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-7.9%
++/-0.2%
 </text>
-<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#273B59" stroke="none"/>
-<rect x="1110" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="1110" y="149" width="71" height="25" opacity="1" fill="#253855" stroke="none"/>
 <text x="1145" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-30.3
+27.4
 </text>
 <text x="1145" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
++/-0.2%
 </text>
-<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#294060" stroke="none"/>
-<rect x="1185" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<rect x="1185" y="149" width="71" height="25" opacity="1" fill="#293F5E" stroke="none"/>
 <text x="1220" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-35.7
+34.5
 </text>
 <text x="1220" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.7%
++/-0.4%
 </text>
-<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
+<rect x="1260" y="149" width="71" height="25" opacity="1" fill="#395C8C" stroke="none"/>
 <text x="1295" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-64.8
+68.1
 </text>
 <text x="1295" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-4.5%
++/-0.4%
 </text>
 <rect x="1335" y="149" width="71" height="25" opacity="1" fill="#5B9BEB" stroke="none"/>
 <rect x="1335" y="149" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1370" y="157" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-138.9
+138.7
 </text>
 <text x="1370" y="168" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-1.9%
++/-0.9%
 </text>
 <text x="28" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="8.870967741935484" opacity="1" fill="#FACC15">
 fanring Coordinated
 </text>
 <rect x="186" y="178" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
 <text x="221" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-18.1
-</text>
-<text x="221" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-16.2%
-</text>
-<rect x="261" y="178" width="71" height="25" opacity="1" fill="#21324B" stroke="none"/>
-<text x="296" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-19.7
-</text>
-<text x="296" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.9%
-</text>
-<rect x="336" y="178" width="71" height="25" opacity="1" fill="#213048" stroke="none"/>
-<text x="371" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
 17.8
 </text>
-<text x="371" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-6.3%
+<text x="221" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-8.8%
 </text>
-<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1E2B40" stroke="none"/>
+<rect x="261" y="178" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<text x="296" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.4
+</text>
+<text x="296" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-4.2%
+</text>
+<rect x="336" y="178" width="71" height="25" opacity="1" fill="#21314A" stroke="none"/>
+<text x="371" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+19.3
+</text>
+<text x="371" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-5.5%
+</text>
+<rect x="411" y="178" width="71" height="25" opacity="1" fill="#1E2A3F" stroke="none"/>
 <text x="446" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-11.9
+11.5
 </text>
 <text x="446" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.3%
++/-2.2%
 </text>
-<rect x="494" y="178" width="71" height="25" opacity="1" fill="#395D8C" stroke="none"/>
+<rect x="494" y="178" width="71" height="25" opacity="1" fill="#375986" stroke="none"/>
 <rect x="494" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="529" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-68.4
+64.0
 </text>
 <text x="529" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-1.1%
 </text>
-<rect x="569" y="178" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<rect x="569" y="178" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
+<rect x="569" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="604" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-61.1
+62.9
 </text>
 <text x="604" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.4%
 </text>
-<rect x="644" y="178" width="71" height="25" opacity="1" fill="#2C4568" stroke="none"/>
+<rect x="644" y="178" width="71" height="25" opacity="1" fill="#2B4467" stroke="none"/>
 <text x="679" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-41.8
+40.6
 </text>
 <text x="679" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-5.7%
++/-4.9%
 </text>
-<rect x="719" y="178" width="71" height="25" opacity="1" fill="#22324C" stroke="none"/>
+<rect x="719" y="178" width="71" height="25" opacity="1" fill="#233550" stroke="none"/>
 <text x="754" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-20.6
+23.4
 </text>
 <text x="754" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-10.9%
++/-7.5%
 </text>
-<rect x="802" y="178" width="71" height="25" opacity="1" fill="#375A88" stroke="none"/>
+<rect x="802" y="178" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
+<rect x="802" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="837" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-65.5
+64.5
 </text>
 <text x="837" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.8%
++/-0.3%
 </text>
-<rect x="877" y="178" width="71" height="25" opacity="1" fill="#355682" stroke="none"/>
+<rect x="877" y="178" width="71" height="25" opacity="1" fill="#365885" stroke="none"/>
+<rect x="877" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="912" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-60.8
+62.8
 </text>
 <text x="912" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="952" y="178" width="71" height="25" opacity="1" fill="#4675B2" stroke="none"/>
-<rect x="952" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
-<text x="987" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-96.2
-</text>
-<text x="987" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.5%
-</text>
-<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#375987" stroke="none"/>
-<text x="1062" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-64.6
-</text>
-<text x="1062" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
-</text>
-<rect x="1110" y="178" width="71" height="25" opacity="1" fill="#263B58" stroke="none"/>
-<text x="1145" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-29.9
-</text>
-<text x="1145" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-0.4%
-</text>
-<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#293F60" stroke="none"/>
-<text x="1220" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-35.5
-</text>
-<text x="1220" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
 +/-0.6%
 </text>
-<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#395D8D" stroke="none"/>
+<rect x="952" y="178" width="71" height="25" opacity="1" fill="#4777B5" stroke="none"/>
+<rect x="952" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="987" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+98.7
+</text>
+<text x="987" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-2.0%
+</text>
+<rect x="1027" y="178" width="71" height="25" opacity="1" fill="#375986" stroke="none"/>
+<text x="1062" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+64.1
+</text>
+<text x="1062" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="1110" y="178" width="71" height="25" opacity="1" fill="#263A57" stroke="none"/>
+<rect x="1110" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1145" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+29.1
+</text>
+<text x="1145" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.2%
+</text>
+<rect x="1185" y="178" width="71" height="25" opacity="1" fill="#294061" stroke="none"/>
+<rect x="1185" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
+<text x="1220" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
+36.4
+</text>
+<text x="1220" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
++/-0.9%
+</text>
+<rect x="1260" y="178" width="71" height="25" opacity="1" fill="#3B6192" stroke="none"/>
 <rect x="1260" y="178" width="71" height="25" opacity="1" fill="none" stroke="#E5E7EB"/>
 <text x="1295" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#E5E7EB">
-69.2
+73.0
 </text>
 <text x="1295" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#E5E7EB">
-+/-3.9%
++/-0.9%
 </text>
-<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#4E83C7" stroke="none"/>
+<rect x="1335" y="178" width="71" height="25" opacity="1" fill="#4C80C2" stroke="none"/>
 <text x="1370" y="186" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="8.064516129032258" opacity="1" fill="#000000">
-111.9
+108.4
 </text>
 <text x="1370" y="197" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="5.645161290322581" opacity="1" fill="#000000">
-+/-0.5%
++/-2.2%
 </text>
 <polyline fill="none" opacity="1" stroke="#374151" stroke-width="1" points="24,240 1416,240 "/>
 <text x="720" y="231" dy="0.5ex" text-anchor="middle" font-family="sans-serif" font-size="7.258064516129032" opacity="1" fill="#9CA3AF">

--- a/src/mpmc/receiver.rs
+++ b/src/mpmc/receiver.rs
@@ -368,11 +368,14 @@ impl<T, P: Teardown> Receiver<T, P> {
             let page_id = group.id() * PAGES_PER_GROUP + page_bit;
             self.direct_page_cursor
                 .set((page_id + 1) % ready.pages.len());
-            if let Some(lane) = ready
-                .pages
-                .get(page_id)
-                .and_then(|page| page.pop_after_claim())
-            {
+            // The shared group can expose work on a page registered after
+            // this snapshot. Resolve that page through the published topology.
+            let lane = if let Some(page) = ready.pages.get(page_id) {
+                page.pop_after_claim()
+            } else {
+                self.shared.ready.load().pages[page_id].pop_after_claim()
+            };
+            if let Some(lane) = lane {
                 return Some((lane, publication));
             }
             drop(publication);
@@ -845,11 +848,60 @@ mod tests {
         assert_eq!(rx.recv(), Err(RecvError));
     }
 
+    fn check_new_page_work_claim<P: Teardown>() {
+        let (tx, mut rx) = channel_with_policy::<_, P>(PREFETCH_LIMIT + 1);
+        let ready = rx.ready.borrow().clone();
+        let mut senders = vec![tx];
+        for _ in 0..LANES_PER_PAGE {
+            senders.push(senders[0].try_clone().unwrap());
+        }
+        for value in 0..=PREFETCH_LIMIT {
+            senders.last_mut().unwrap().try_send(value).unwrap();
+        }
+        // A receiver with the new topology drains one batch and requeues
+        // the remaining value before the stale receiver claims the work bit.
+        let mut fresh = rx.clone();
+        for expected in 0..PREFETCH_LIMIT {
+            assert_eq!(fresh.try_recv(), Ok(expected));
+        }
+        let claimed = rx.acquire_work_lane(&ready).map(|(lane, publication)| {
+            let drained = rx.drain_lane(lane);
+            drop(publication);
+            let LaneDrain::Item { value, effects } = drained else {
+                panic!("requeued lane has a remaining value");
+            };
+            rx.apply_effects(effects);
+            value
+        });
+        // Claiming a bit through an older topology must not lose access to
+        // the lane. A deferred claim must leave it reachable on the next scan.
+        assert_eq!(
+            claimed.map_or_else(|| rx.try_recv(), Ok),
+            Ok(PREFETCH_LIMIT)
+        );
+        drop(senders);
+        assert_eq!(rx.recv(), Err(RecvError));
+    }
+
     #[test]
     fn requeue_new_page_after_acquiring_through_stale_topology() {
         let checks: [fn(); 2] = [
             check_new_page_requeue::<Deferred>,
             check_new_page_requeue::<Coordinated>,
+        ];
+        for check in checks {
+            #[cfg(loom)]
+            loom::model(check);
+            #[cfg(not(loom))]
+            check();
+        }
+    }
+
+    #[test]
+    fn claim_new_page_work_through_stale_topology() {
+        let checks: [fn(); 2] = [
+            check_new_page_work_claim::<Deferred>,
+            check_new_page_work_claim::<Coordinated>,
         ];
         for check in checks {
             #[cfg(loom)]

--- a/src/mpmc/receiver.rs
+++ b/src/mpmc/receiver.rs
@@ -487,7 +487,15 @@ impl<T, P: Teardown> Receiver<T, P> {
 
     fn requeue_lane(&self, lane: LaneToken<T, P>) {
         let page_id = lane.key.slot / super::LANES_PER_PAGE;
-        self.ready.borrow().pages[page_id].push(lane);
+        let ready = self.ready.borrow();
+        if let Some(page) = ready.pages.get(page_id) {
+            page.push(lane);
+        } else {
+            // A shared readiness group can expose a newly registered page
+            // after our snapshot refresh. Registry activation happens after
+            // that page's topology is published, so the shared snapshot has it.
+            self.shared.ready.load().pages[page_id].push(lane);
+        }
     }
 
     fn refresh_ready_topology(&self) {
@@ -797,4 +805,57 @@ impl Effects {
 pub(super) fn close_lane<T, P: Teardown>(mut lane: LaneToken<T, P>) {
     lane.consumer.close();
     lane.signal.notify_space();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LaneDrain, PREFETCH_LIMIT, RecvError};
+    use crate::mpmc::{LANES_PER_PAGE, channel_with_policy};
+    use crate::teardown::{Coordinated, Deferred, Teardown};
+
+    fn check_new_page_requeue<P: Teardown>() {
+        let (tx, mut rx) = channel_with_policy::<_, P>(PREFETCH_LIMIT + 1);
+        // Registration can happen after acquire_lane refreshes its snapshot
+        // and before acquire_ready_lane claims a bit in an existing group.
+        let ready = rx.ready.borrow().clone();
+        assert_eq!(ready.pages.len(), 1);
+        let mut senders = vec![tx];
+        for _ in 0..LANES_PER_PAGE {
+            senders.push(senders[0].try_clone().unwrap());
+        }
+        for value in 0..=PREFETCH_LIMIT {
+            senders.last_mut().unwrap().try_send(value).unwrap();
+        }
+
+        let (lane, publication) = rx.acquire_ready_lane(&ready).unwrap();
+        assert_eq!(lane.key.slot, LANES_PER_PAGE);
+        // One value remains in the newly registered ring after the first
+        // batch, forcing the normal drain path to requeue its lane token.
+        let drained = rx.drain_lane(lane);
+        drop(publication);
+        let LaneDrain::Item { value, effects } = drained else {
+            panic!("newly registered lane has a published batch");
+        };
+        rx.apply_effects(effects);
+        assert_eq!(value, 0);
+        for expected in 1..=PREFETCH_LIMIT {
+            assert_eq!(rx.try_recv(), Ok(expected));
+        }
+        drop(senders);
+        assert_eq!(rx.recv(), Err(RecvError));
+    }
+
+    #[test]
+    fn requeue_new_page_after_acquiring_through_stale_topology() {
+        let checks: [fn(); 2] = [
+            check_new_page_requeue::<Deferred>,
+            check_new_page_requeue::<Coordinated>,
+        ];
+        for check in checks {
+            #[cfg(loom)]
+            loom::model(check);
+            #[cfg(not(loom))]
+            check();
+        }
+    }
 }


### PR DESCRIPTION
- Fix MPMC panics and unreachable queued work when sender registration exposes a page absent from a receiver's cached topology.
- Resolve missing pages through the published topology when claiming requeued work and returning partially drained lanes.
- Add deterministic regressions for both interleavings under `Deferred` and `Coordinated`.
- Document that immutable topology vectors still reference shared, mutable readiness groups.
- Refresh the `u64` MPMC throughput chart for `Deferred` and `Coordinated` after the topology fixes.
