### PR TITLE
feat: add explicit MPSC slot release and batch receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- MPSC `Receiver::release_consumed` publishes consumed slots across sender
+  lanes and notifies blocked senders, including after partial receive batches.
+- MPSC `Receiver::recv_batch_into` appends a bounded batch to a caller-owned
+  vector, waits only for the first value, and releases consumed slots before
+  returning.
+
 ## [0.3.3] - 2026-09-08
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -113,6 +113,15 @@ or when the lane reaches visible empty. A full release batch can span several
 prefetch windows. Empty-lane release prevents a producer and receiver from
 parking while partial credits remain unpublished.
 
+Single-value receives can therefore return before their slots become reusable
+by the sender. `Receiver::release_consumed` scans the receiver's lane slots,
+publishes each lane's pending consumed capacity, and notifies its space waiter.
+It preserves unread prefetched values and the scheduling counters.
+`recv_batch_into` appends a bounded number of values to a caller-owned vector,
+blocks only for the first value, and calls `release_consumed` before returning.
+Applications can use either API before issuing completions or returning permits
+that admit more sends.
+
 ## MPMC Receive Path
 
 Each receiver has a private deque for sole-receiver staging and a bounded,

--- a/README.md
+++ b/README.md
@@ -89,8 +89,28 @@ drop(rx);
 assert_eq!(tx0.send("closed").unwrap_err().into_inner(), "closed");
 ```
 
-`mpsc` keeps receive-side batching entirely inside `recv`/`try_recv`. It
-preserves FIFO within each sender lane and relaxes order across senders.
+`mpsc` preserves FIFO within each sender lane and relaxes order across senders.
+Single-value receives batch slot release: receiving a value may leave its slot
+unavailable to the sender until a later receive. Call `rx.release_consumed()`
+before returning application permits or issuing completions that allow more
+sends. This publishes freed slots across sender lanes and wakes blocked senders.
+
+To receive a bounded batch into reusable storage:
+
+```rust
+let mut batch = Vec::with_capacity(32);
+while rx.recv_batch_into(&mut batch, 32).is_ok() {
+    for value in batch.drain(..) {
+        // Process value. Its ring slot is already reusable.
+    }
+}
+```
+
+`recv_batch_into` appends at most the requested limit, waits only for the first
+value, and releases consumed slots before returning. It returns the number
+appended; a partial batch succeeds even after disconnect. Reserve enough spare
+vector capacity to avoid output reallocations. A zero limit receives nothing,
+releases consumed slots, and returns `Ok(0)`.
 
 ## MPMC
 

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -2,6 +2,12 @@
 //!
 //! Each sender owns its ring producer and the receiver owns every ring
 //! consumer. Ordering is FIFO per sender and relaxed across senders.
+//!
+//! Single-value receives batch slot release, so a sender can still observe
+//! `Full` after values have been received. [`Receiver::release_consumed`]
+//! publishes those freed slots immediately. [`Receiver::recv_batch_into`]
+//! receives a bounded batch into a caller-owned vector and releases consumed
+//! slots before returning, waiting only for the first value.
 
 use crate::teardown::{Deferred, Teardown};
 

--- a/src/mpsc/receiver.rs
+++ b/src/mpsc/receiver.rs
@@ -18,6 +18,12 @@ use super::{
 /// The receiver owns every SPSC consumer and drains active lanes in bounded
 /// round-robin bursts. It is `Send` when `T` is `Send`, but it is not `Sync`.
 ///
+/// Single-value receives batch slot release, so receiving a value does not
+/// necessarily make its slot immediately reusable by the sender. Call
+/// [`release_consumed`](Self::release_consumed) or use
+/// [`recv_batch_into`](Self::recv_batch_into) to publish freed slots before
+/// processing received values.
+///
 /// Dropping the last receiver disconnects senders. Unread payload destruction
 /// follows `P`: [`Deferred`] may retain ring values until their sender drops;
 /// [`Coordinated`](crate::teardown::Coordinated) reclaims them during teardown
@@ -36,6 +42,9 @@ pub struct Receiver<T, P: Teardown = Deferred> {
 
 impl<T, P: Teardown> Receiver<T, P> {
     /// Try to receive one value.
+    ///
+    /// Consumed slots are released in batches. Use
+    /// [`release_consumed`](Self::release_consumed) to release them immediately.
     ///
     /// # Errors
     ///
@@ -140,6 +149,9 @@ impl<T, P: Teardown> Receiver<T, P> {
 
     /// Receive one value, blocking while the channel is empty.
     ///
+    /// Consumed slots are released in batches. Use
+    /// [`release_consumed`](Self::release_consumed) to release them immediately.
+    ///
     /// # Errors
     ///
     /// Returns [`RecvError`] after all senders and buffered values are gone.
@@ -158,6 +170,102 @@ impl<T, P: Teardown> Receiver<T, P> {
                 Err(TryRecvError::Empty) => return self.recv_slow(),
             }
         }
+    }
+
+    /// Publish all consumed slots and notify senders waiting for capacity.
+    ///
+    /// This releases slots consumed by earlier receives across all sender
+    /// lanes, including partial batches. It does not receive more values or
+    /// release unread slots. Calling it again without receiving more values
+    /// has no effect.
+    ///
+    /// Call this before returning application permits or issuing completions
+    /// that allow producers to send more work.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use fanring::mpsc::{channel, TrySendError};
+    ///
+    /// let (mut tx, mut rx) = channel(4);
+    /// for value in 0..4 {
+    ///     tx.try_send(value).unwrap();
+    /// }
+    /// assert_eq!(rx.recv(), Ok(0));
+    /// assert_eq!(rx.recv(), Ok(1));
+    /// assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
+    /// rx.release_consumed();
+    /// assert_eq!(tx.try_send(4), Ok(()));
+    /// assert_eq!(tx.try_send(5), Ok(()));
+    /// ```
+    pub fn release_consumed(&mut self) {
+        for lane in self.lanes.iter_mut().flatten() {
+            if lane.release_pending() {
+                lane.signal.notify_space();
+            }
+        }
+    }
+
+    /// Append up to `limit` values to `output`, returning the number appended.
+    ///
+    /// Waits only for the first value. Subsequent receives are nonblocking and
+    /// stop when no value is immediately available or `limit` is reached.
+    /// Existing output values are preserved. FIFO ordering within each sender
+    /// lane is the same as for single-value receives.
+    ///
+    /// Before returning, publishes all consumed slots and notifies senders
+    /// waiting for capacity, including slots consumed by earlier receive calls.
+    /// A zero limit receives nothing, releases consumed slots, and returns
+    /// `Ok(0)` even if the channel is disconnected.
+    ///
+    /// The output vector grows as needed. Reserve space for `limit` additional
+    /// values before calling to avoid reallocating it. Receiver topology may
+    /// still allocate when new senders are registered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RecvError`] only when `limit` is nonzero and all senders and
+    /// buffered values are gone before receiving the first value. A partial
+    /// batch returns `Ok(count)` even if the channel disconnects.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use fanring::mpsc::channel;
+    ///
+    /// let (mut tx, mut rx) = channel(4);
+    /// for value in 0..4 {
+    ///     tx.try_send(value).unwrap();
+    /// }
+    /// let mut batch = Vec::with_capacity(2);
+    /// assert_eq!(rx.recv_batch_into(&mut batch, 2), Ok(2));
+    /// assert_eq!(batch, [0, 1]);
+    /// assert_eq!(tx.try_send(4), Ok(()));
+    /// assert_eq!(tx.try_send(5), Ok(()));
+    /// ```
+    pub fn recv_batch_into(
+        &mut self,
+        output: &mut Vec<T>,
+        limit: usize,
+    ) -> Result<usize, RecvError> {
+        let result = if limit == 0 {
+            Ok(0)
+        } else {
+            self.recv().map(|first| {
+                output.push(first);
+                let mut received = 1;
+                while received < limit {
+                    let Ok(value) = self.try_recv() else {
+                        break;
+                    };
+                    output.push(value);
+                    received += 1;
+                }
+                received
+            })
+        };
+        self.release_consumed();
+        result
     }
 
     #[cold]

--- a/src/mpsc/sender.rs
+++ b/src/mpsc/sender.rs
@@ -52,6 +52,10 @@ impl<T, P: Teardown> Sender<T, P> {
     ///
     /// A successful send is immediately visible to the receiver. Internally,
     /// the value is pushed into this sender's SPSC ring and flushed.
+    /// Consumed slots remain occupied until the receiver releases them. Use
+    /// [`Receiver::release_consumed`](super::Receiver::release_consumed) or
+    /// [`Receiver::recv_batch_into`](super::Receiver::recv_batch_into) when
+    /// capacity must be reusable before processing received values.
     ///
     /// # Errors
     ///

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -436,6 +436,144 @@ fn blocking_send_does_not_lose_space_wakeup() {
 }
 
 #[test]
+fn mpsc_release_consumed_does_not_lose_space_wakeup() {
+    fn check<P: fanring::teardown::Teardown>() {
+        model(|| {
+            let (mut tx, mut rx) = fanring::mpsc::channel_with_policy::<_, P>(2);
+            tx.try_send(0).unwrap();
+            tx.try_send(1).unwrap();
+            let sender = thread::spawn(move || {
+                tx.send(2).unwrap();
+                tx
+            });
+
+            assert_eq!(rx.recv(), Ok(0));
+            rx.release_consumed();
+            let tx = sender.join().unwrap();
+            assert_eq!(rx.recv(), Ok(1));
+            assert_eq!(rx.recv(), Ok(2));
+            drop(tx);
+            assert_eq!(rx.recv(), Err(RecvError));
+        });
+    }
+    check::<fanring::teardown::Deferred>();
+    check::<fanring::teardown::Coordinated>();
+}
+
+#[test]
+fn mpsc_recv_batch_releases_capacity_before_returning() {
+    fn check<P: fanring::teardown::Teardown>() {
+        model(|| {
+            let (mut tx, mut rx) = fanring::mpsc::channel_with_policy::<_, P>(2);
+            tx.try_send(0).unwrap();
+            tx.try_send(1).unwrap();
+            let sender = thread::spawn(move || {
+                tx.send(2).unwrap();
+                tx
+            });
+
+            let mut output = Vec::with_capacity(1);
+            assert_eq!(rx.recv_batch_into(&mut output, 1), Ok(1));
+            assert_eq!(output, [0]);
+            let tx = sender.join().unwrap();
+            assert_eq!(rx.recv(), Ok(1));
+            assert_eq!(rx.recv(), Ok(2));
+            drop(tx);
+        });
+    }
+    check::<fanring::teardown::Deferred>();
+    check::<fanring::teardown::Coordinated>();
+}
+
+#[test]
+fn mpsc_recv_batch_waits_only_for_first_value() {
+    fn check<P: fanring::teardown::Teardown>() {
+        model(|| {
+            let (mut tx, mut rx) = fanring::mpsc::channel_with_policy::<_, P>(2);
+            let receiver = thread::spawn(move || {
+                let mut output = Vec::with_capacity(2);
+                assert_eq!(rx.recv_batch_into(&mut output, 2), Ok(1));
+                assert_eq!(output, [7]);
+                rx
+            });
+            tx.send(7).unwrap();
+            // Join before disconnecting. Waiting for a second value would
+            // deadlock, while returning before the first would fail above.
+            let mut rx = receiver.join().unwrap();
+            tx.try_send(8).unwrap();
+            tx.try_send(9).unwrap();
+            assert_eq!(tx.try_send(10), Err(TrySendError::Full(10)));
+            drop(tx);
+            assert_eq!(rx.iter().collect::<Vec<_>>(), [8, 9]);
+        });
+    }
+    check::<fanring::teardown::Deferred>();
+    check::<fanring::teardown::Coordinated>();
+}
+
+#[test]
+fn mpsc_recv_batch_wakes_on_last_sender_drop() {
+    fn check<P: fanring::teardown::Teardown>() {
+        model(|| {
+            let (tx, mut rx) = fanring::mpsc::channel_with_policy::<_, P>(2);
+            let sender = thread::spawn(move || drop(tx));
+            let mut output = vec![7];
+            assert_eq!(rx.recv_batch_into(&mut output, 2), Err(RecvError));
+            assert_eq!(output, [7]);
+            sender.join().unwrap();
+        });
+    }
+    check::<fanring::teardown::Deferred>();
+    check::<fanring::teardown::Coordinated>();
+}
+
+#[test]
+fn mpsc_recv_batch_slot_refill_racing_receiver_drop_preserves_ownership() {
+    fn check<P: fanring::teardown::Teardown>() {
+        model(|| {
+            let (mut tx, mut rx) = fanring::mpsc::channel_with_policy::<_, P>(2);
+            let first = Arc::new(loom::sync::atomic::AtomicUsize::new(0));
+            let unread = Arc::new(loom::sync::atomic::AtomicUsize::new(0));
+            let refill = Arc::new(loom::sync::atomic::AtomicUsize::new(0));
+            tx.try_send(DropCount(first.clone())).unwrap();
+            tx.try_send(DropCount(unread.clone())).unwrap();
+            let value = DropCount(refill.clone());
+            let sender = thread::spawn(move || {
+                let sent = match tx.send(value) {
+                    Ok(()) => true,
+                    Err(error) => {
+                        drop(error);
+                        false
+                    }
+                };
+                (tx, sent)
+            });
+
+            let mut output = Vec::with_capacity(1);
+            assert_eq!(rx.recv_batch_into(&mut output, 1), Ok(1));
+            // The sender can reuse the released slot while the receiver closes
+            // a window still containing the unread value.
+            drop(rx);
+            let (tx, sent) = sender.join().unwrap();
+            assert_eq!(first.load(Ordering::Relaxed), 0);
+            assert_eq!(unread.load(Ordering::Relaxed), usize::from(P::COORDINATED));
+            assert_eq!(
+                refill.load(Ordering::Relaxed),
+                usize::from(P::COORDINATED || !sent)
+            );
+            drop(tx);
+            assert_eq!(first.load(Ordering::Relaxed), 0);
+            assert_eq!(unread.load(Ordering::Relaxed), 1);
+            assert_eq!(refill.load(Ordering::Relaxed), 1);
+            drop(output);
+            assert_eq!(first.load(Ordering::Relaxed), 1);
+        });
+    }
+    check::<fanring::teardown::Deferred>();
+    check::<fanring::teardown::Coordinated>();
+}
+
+#[test]
 fn blocking_send_recv_do_not_deadlock_while_sender_stays_alive() {
     model(|| {
         let (mut tx, mut rx) = channel(1);

--- a/tests/mpsc_batch.rs
+++ b/tests/mpsc_batch.rs
@@ -1,0 +1,321 @@
+use fanring::mpsc::{RecvError, TryRecvError, TrySendError, channel_with_policy};
+use fanring::teardown::{Coordinated, Deferred, Teardown};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+#[test]
+fn release_consumed_preserves_unread_values_and_is_idempotent() {
+    fn check<P: Teardown>() {
+        let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+        for value in 0..4 {
+            tx.try_send(value).unwrap();
+        }
+        rx.release_consumed();
+        assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
+        assert_eq!(rx.try_recv(), Ok(0));
+        assert_eq!(rx.recv(), Ok(1));
+        assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
+
+        rx.release_consumed();
+        rx.release_consumed();
+        tx.try_send(4).unwrap();
+        tx.try_send(5).unwrap();
+        assert_eq!(tx.try_send(6), Err(TrySendError::Full(6)));
+        assert_eq!(rx.try_iter().collect::<Vec<_>>(), [2, 3, 4, 5]);
+        rx.release_consumed();
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn release_consumed_covers_all_lanes_without_resetting_rotation() {
+    fn check<P: Teardown>() {
+        let (mut tx0, mut rx) = channel_with_policy::<_, P>(128);
+        let mut tx1 = tx0.try_clone().unwrap();
+        for value in 0..128 {
+            tx0.try_send((0, value)).unwrap();
+            tx1.try_send((1, value)).unwrap();
+        }
+        assert_eq!(rx.recv(), Ok((0, 0)));
+        rx.release_consumed();
+        tx0.try_send((0, 128)).unwrap();
+
+        // Offset lane 0's release boundary from its rotation boundary so both
+        // lanes hold partial release batches when lane 1 becomes active.
+        for value in 1..64 {
+            assert_eq!(rx.try_recv(), Ok((0, value)));
+        }
+        assert_eq!(rx.recv(), Ok((1, 0)));
+        assert_eq!(tx0.try_send((0, 129)), Err(TrySendError::Full((0, 129))));
+        assert_eq!(tx1.try_send((1, 128)), Err(TrySendError::Full((1, 128))));
+        rx.release_consumed();
+        for value in 129..192 {
+            tx0.try_send((0, value)).unwrap();
+        }
+        tx1.try_send((1, 128)).unwrap();
+        assert_eq!(tx0.try_send((0, 192)), Err(TrySendError::Full((0, 192))));
+        assert_eq!(tx1.try_send((1, 129)), Err(TrySendError::Full((1, 129))));
+
+        drop((tx0, tx1));
+        let mut next = [64, 1];
+        for (lane, value) in rx {
+            assert_eq!(value, next[lane]);
+            next[lane] += 1;
+        }
+        assert_eq!(next, [192, 129]);
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn recv_batch_appends_bounded_values_and_releases_earlier_receives() {
+    fn check<P: Teardown>() {
+        let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+        for value in 0..4 {
+            tx.try_send(value).unwrap();
+        }
+        assert_eq!(rx.recv(), Ok(0));
+        let mut output = Vec::with_capacity(3);
+        output.push(-1);
+        let allocation = output.as_ptr();
+        let capacity = output.capacity();
+        assert_eq!(rx.recv_batch_into(&mut output, 1), Ok(1));
+        assert_eq!(output, [-1, 1]);
+        assert_eq!(output.as_ptr(), allocation);
+        assert_eq!(output.capacity(), capacity);
+        tx.try_send(4).unwrap();
+        tx.try_send(5).unwrap();
+        assert_eq!(tx.try_send(6), Err(TrySendError::Full(6)));
+
+        output.clear();
+        assert_eq!(rx.recv_batch_into(&mut output, 2), Ok(2));
+        assert_eq!(output, [2, 3]);
+        assert_eq!(output.as_ptr(), allocation);
+        output.clear();
+        assert_eq!(rx.recv_batch_into(&mut output, 3), Ok(2));
+        assert_eq!(output, [4, 5]);
+        assert_eq!(output.capacity(), capacity);
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn recv_batch_waits_only_for_first_value() {
+    fn check<P: Teardown>() {
+        let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let receiver = std::thread::spawn(move || {
+            let mut output = Vec::with_capacity(4);
+            started_tx.send(()).unwrap();
+            let result = rx.recv_batch_into(&mut output, 4);
+            done_tx.send((result, output)).unwrap();
+        });
+        started_rx.recv().unwrap();
+        tx.send(7).unwrap();
+        // Keep the sender connected until the batch returns. Disconnect on
+        // failure as well, so an implementation waiting for more can exit.
+        let result = done_rx.recv_timeout(Duration::from_secs(5));
+        drop(tx);
+        receiver.join().unwrap();
+        assert_eq!(result.unwrap(), (Ok(1), vec![7]));
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn recv_batch_zero_limit_releases_without_receiving() {
+    fn check<P: Teardown>() {
+        let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+        let mut output = vec![9];
+        assert_eq!(rx.recv_batch_into(&mut output, 0), Ok(0));
+        for value in 0..4 {
+            tx.try_send(value).unwrap();
+        }
+        assert_eq!(rx.recv(), Ok(0));
+        assert_eq!(rx.recv_batch_into(&mut output, 0), Ok(0));
+        assert_eq!(output, [9]);
+        tx.try_send(4).unwrap();
+        drop(tx);
+        assert_eq!(rx.recv_batch_into(&mut output, 0), Ok(0));
+        // A large limit must not cause an up-front allocation for that limit.
+        assert_eq!(rx.recv_batch_into(&mut output, usize::MAX), Ok(4));
+        assert_eq!(output, [9, 1, 2, 3, 4]);
+        assert_eq!(rx.recv_batch_into(&mut output, 1), Err(RecvError));
+        assert_eq!(rx.recv_batch_into(&mut output, 0), Ok(0));
+        assert_eq!(output, [9, 1, 2, 3, 4]);
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn recv_batch_disconnect_preserves_partial_batch_and_owned_values() {
+    fn check<P: Teardown>() {
+        let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+        tx.send(Box::new(1)).unwrap();
+        tx.send(Box::new(2)).unwrap();
+        drop(tx);
+        let mut output = vec![Box::new(0)];
+        assert_eq!(rx.recv_batch_into(&mut output, 4), Ok(2));
+        assert_eq!(
+            output.iter().map(|value| **value).collect::<Vec<_>>(),
+            [0, 1, 2]
+        );
+        assert_eq!(rx.recv_batch_into(&mut output, 4), Err(RecvError));
+        drop(rx);
+        assert_eq!(
+            output.iter().map(|value| **value).collect::<Vec<_>>(),
+            [0, 1, 2]
+        );
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn recv_batch_reclaims_exact_capacity_across_wraparound_and_release_boundaries() {
+    fn check<P: Teardown>() {
+        for requested_capacity in [1, 3, 64, 65] {
+            let (mut tx, mut rx) = channel_with_policy::<_, P>(requested_capacity);
+            let capacity = rx.capacity_per_sender();
+            for value in 0..capacity {
+                tx.try_send(value).unwrap();
+            }
+            let mut sent = capacity;
+            let mut received = 0;
+            let mut output = Vec::with_capacity(capacity);
+            // Cross the 64-item release boundary and repeatedly reuse physical
+            // slots, including capacities rounded upward by yring.
+            for limit in [1, 3, 63, 64, 65, 129] {
+                let count = capacity.min(limit);
+                assert_eq!(rx.recv_batch_into(&mut output, limit), Ok(count));
+                assert_eq!(output, (received..received + count).collect::<Vec<_>>());
+                received += count;
+                output.clear();
+
+                for value in sent..sent + count {
+                    tx.try_send(value).unwrap();
+                }
+                sent += count;
+                assert_eq!(tx.try_send(sent), Err(TrySendError::Full(sent)));
+            }
+            drop(tx);
+            assert_eq!(rx.recv_batch_into(&mut output, capacity + 1), Ok(capacity));
+            assert_eq!(output, (received..sent).collect::<Vec<_>>());
+            assert_eq!(rx.recv_batch_into(&mut output, 1), Err(RecvError));
+        }
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[test]
+fn recv_batch_retires_and_reuses_lane_without_releasing_new_unread_slots() {
+    fn check<P: Teardown>() {
+        let (root, mut rx) = channel_with_policy::<_, P>(4);
+        let mut old = root.try_clone().unwrap();
+        let slot = old.lane_id();
+        for value in 0..4 {
+            old.try_send(value).unwrap();
+        }
+        let mut output = Vec::with_capacity(4);
+        assert_eq!(rx.recv_batch_into(&mut output, 2), Ok(2));
+        assert_eq!(output, [0, 1]);
+        drop(old);
+        output.clear();
+        assert_eq!(rx.recv_batch_into(&mut output, 4), Ok(2));
+        assert_eq!(output, [2, 3]);
+        // The empty poll retires this lane, leaving a hole in the receiver's
+        // lane table. Releasing again must tolerate that hole.
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+        rx.release_consumed();
+
+        let mut new = root.try_clone().unwrap();
+        assert_eq!(new.lane_id(), slot);
+        for value in 4..8 {
+            new.try_send(value).unwrap();
+        }
+        // The reused slot is registered but has not been imported or read yet.
+        rx.release_consumed();
+        assert_eq!(new.try_send(8), Err(TrySendError::Full(8)));
+        output.clear();
+        assert_eq!(rx.recv_batch_into(&mut output, 1), Ok(1));
+        assert_eq!(output, [4]);
+        new.try_send(8).unwrap();
+        assert_eq!(new.try_send(9), Err(TrySendError::Full(9)));
+        drop((root, new));
+        output.clear();
+        assert_eq!(rx.recv_batch_into(&mut output, 5), Ok(4));
+        assert_eq!(output, [5, 6, 7, 8]);
+        rx.release_consumed();
+        assert_eq!(rx.recv_batch_into(&mut output, 1), Err(RecvError));
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}
+
+#[derive(Debug)]
+struct Counted {
+    id: usize,
+    drops: Arc<Vec<AtomicUsize>>,
+}
+
+impl Drop for Counted {
+    fn drop(&mut self) {
+        assert_eq!(self.drops[self.id].fetch_add(1, Ordering::Relaxed), 0);
+    }
+}
+
+#[test]
+fn released_slot_reuse_and_receiver_drop_preserve_output_ownership() {
+    fn check<P: Teardown>() {
+        for explicit_release in [false, true] {
+            let drops = Arc::new((0..6).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>());
+            let value = |id| Counted {
+                id,
+                drops: drops.clone(),
+            };
+            let (mut tx, mut rx) = channel_with_policy::<_, P>(4);
+            for id in 0..4 {
+                tx.try_send(value(id)).unwrap();
+            }
+            let mut output = Vec::with_capacity(2);
+            if explicit_release {
+                output.push(rx.recv().unwrap());
+                output.push(rx.recv().unwrap());
+                rx.release_consumed();
+            } else {
+                assert_eq!(rx.recv_batch_into(&mut output, 2), Ok(2));
+            }
+            tx.try_send(value(4)).unwrap();
+            tx.try_send(value(5)).unwrap();
+            assert!(drops.iter().all(|count| count.load(Ordering::Relaxed) == 0));
+
+            drop(rx);
+            for count in &drops[2..] {
+                assert_eq!(count.load(Ordering::Relaxed), usize::from(P::COORDINATED));
+            }
+            drop(tx);
+            for count in &drops[2..] {
+                assert_eq!(count.load(Ordering::Relaxed), 1);
+            }
+            assert_eq!(
+                output.iter().map(|value| value.id).collect::<Vec<_>>(),
+                [0, 1]
+            );
+            assert_eq!(drops[0].load(Ordering::Relaxed), 0);
+            assert_eq!(drops[1].load(Ordering::Relaxed), 0);
+            drop(output);
+            assert!(drops.iter().all(|count| count.load(Ordering::Relaxed) == 1));
+        }
+    }
+    check::<Deferred>();
+    check::<Coordinated>();
+}


### PR DESCRIPTION
- Add `mpsc::Receiver::release_consumed()` to publish freed slots and wake blocked senders before completions or permits admit more work.
- Add `mpsc::Receiver::recv_batch_into(&mut Vec<T>, limit)` to append a bounded batch, wait only for the first item, and release consumed slots before returning.
- Document delayed capacity reuse for single-value receives.
- Cover wakeup and teardown races, ring wraparound, lane reuse, and payload ownership under `Deferred` and `Coordinated` with native tests and Loom models.
